### PR TITLE
Add runtime orchestrator and update Streamlit app integration

### DIFF
--- a/agent_runtime/__init__.py
+++ b/agent_runtime/__init__.py
@@ -1,0 +1,18 @@
+"""Runtime components for the database agent."""
+
+from .orchestrator import AgentOrchestrator, AgentRuntimeClient, OrchestratorEvent, OrchestratorEventType
+from .config_service import ConfigService
+from .memory import ConversationMemory
+from .tool_registry import ToolRegistry, SQLExecutionTool, create_sqlalchemy_tool
+
+__all__ = [
+    "AgentOrchestrator",
+    "AgentRuntimeClient",
+    "OrchestratorEvent",
+    "OrchestratorEventType",
+    "ConfigService",
+    "ConversationMemory",
+    "ToolRegistry",
+    "SQLExecutionTool",
+    "create_sqlalchemy_tool",
+]

--- a/agent_runtime/config_service.py
+++ b/agent_runtime/config_service.py
@@ -1,0 +1,38 @@
+"""Configuration service for the agent runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import os
+
+
+@dataclass
+class ConfigService:
+    """Simple in-memory configuration service with optional environment export."""
+
+    initial_config: Optional[Dict[str, Any]] = None
+    _config: Dict[str, Any] = field(default_factory=dict, init=False)
+
+    def __post_init__(self) -> None:
+        if self.initial_config:
+            self._config.update(self.initial_config)
+
+    def update(self, new_config: Dict[str, Any]) -> None:
+        """Update the configuration with new values."""
+        if not new_config:
+            return
+        self._config.update({k: v for k, v in new_config.items() if v is not None})
+
+    def get_config(self) -> Dict[str, Any]:
+        """Return a copy of the current configuration."""
+        return dict(self._config)
+
+    def get(self, key: str, default: Optional[Any] = None) -> Any:
+        return self._config.get(key, default)
+
+    def export_to_env(self) -> None:
+        """Export the configuration values to environment variables."""
+        for key, value in self._config.items():
+            if value is None:
+                continue
+            os.environ[key] = str(value)

--- a/agent_runtime/memory.py
+++ b/agent_runtime/memory.py
@@ -1,0 +1,29 @@
+"""Conversation memory primitives."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class MemoryRecord:
+    """Representation of a single interaction."""
+
+    nl_query: str
+    sql: str
+
+
+class ConversationMemory:
+    """Simple in-memory store of NL/SQL pairs."""
+
+    def __init__(self) -> None:
+        self._history: List[MemoryRecord] = []
+
+    def add(self, record: MemoryRecord) -> None:
+        self._history.append(record)
+
+    def add_interaction(self, nl_query: str, sql: str) -> None:
+        self.add(MemoryRecord(nl_query=nl_query, sql=sql))
+
+    def get_history(self) -> List[MemoryRecord]:
+        return list(self._history)

--- a/agent_runtime/orchestrator.py
+++ b/agent_runtime/orchestrator.py
@@ -1,0 +1,181 @@
+"""Agent orchestrator and runtime client."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, AsyncGenerator, Generator, List, Optional
+import threading
+import queue
+
+from textgen.factory import LLMClientFactory
+
+from .config_service import ConfigService
+from .memory import ConversationMemory
+from .tool_registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class OrchestratorEventType(str, Enum):
+    STATUS = "status"
+    SQL = "sql"
+    RESULT = "result"
+    ERROR = "error"
+
+
+@dataclass
+class OrchestratorEvent:
+    type: OrchestratorEventType
+    payload: Any
+
+
+class AgentOrchestrator:
+    """Coordinates LLM and tool interactions for NL -> SQL execution."""
+
+    def __init__(
+        self,
+        config_service: ConfigService,
+        tool_registry: ToolRegistry,
+        llm_client_factory: Any = LLMClientFactory,
+        memory: Optional[ConversationMemory] = None,
+        sql_tool_name: str = "sql",
+    ) -> None:
+        self.config_service = config_service
+        self.tool_registry = tool_registry
+        self.llm_client_factory = llm_client_factory
+        self.memory = memory or ConversationMemory()
+        self.sql_tool_name = sql_tool_name
+
+    async def run_nl_query_async(self, nl_query: str) -> AsyncGenerator[OrchestratorEvent, None]:
+        if not nl_query or not nl_query.strip():
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, "Natural language query cannot be empty.")
+            return
+
+        try:
+            tool = self.tool_registry.get(self.sql_tool_name)
+        except KeyError as exc:
+            message = str(exc)
+            logger.error("SQL tool missing: %s", message)
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, message)
+            return
+
+        config = self.config_service.get_config()
+        if not config:
+            msg = "Runtime configuration is empty."
+            logger.error(msg)
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, msg)
+            return
+
+        yield OrchestratorEvent(OrchestratorEventType.STATUS, "Retrieving database schema...")
+
+        try:
+            schema = await asyncio.to_thread(tool.get_schema, config)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            logger.exception("Failed to fetch schema")
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, f"Failed to fetch schema: {exc}")
+            return
+
+        if not schema:
+            message = "Database schema is empty; cannot generate SQL."
+            logger.error(message)
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, message)
+            return
+
+        yield OrchestratorEvent(OrchestratorEventType.STATUS, "Generating SQL using LLM...")
+
+        try:
+            llm_client = self._build_llm_client(config)
+            sql_query = await asyncio.to_thread(llm_client.generate_sql, nl_query, schema)
+        except Exception as exc:
+            logger.exception("Failed to generate SQL")
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, f"Failed to generate SQL: {exc}")
+            return
+
+        self.memory.add_interaction(nl_query=nl_query, sql=sql_query)
+        yield OrchestratorEvent(OrchestratorEventType.SQL, sql_query)
+
+        yield OrchestratorEvent(OrchestratorEventType.STATUS, "Executing SQL query...")
+
+        try:
+            result = await asyncio.to_thread(tool.run_query, config, sql_query)
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            logger.exception("Failed to execute SQL")
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, f"Failed to execute SQL: {exc}")
+            return
+
+        if isinstance(result, str):
+            yield OrchestratorEvent(OrchestratorEventType.ERROR, result)
+            return
+
+        yield OrchestratorEvent(OrchestratorEventType.RESULT, result)
+
+    def run_nl_query(self, nl_query: str) -> List[OrchestratorEvent]:
+        """Synchronous helper to collect orchestrator events."""
+
+        async def collect() -> List[OrchestratorEvent]:
+            return [event async for event in self.run_nl_query_async(nl_query)]
+
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(collect())
+        finally:
+            loop.close()
+
+    def _build_llm_client(self, config: Any) -> Any:
+        backend = (config.get("LLM_BACKEND") or config.get("LLM") or "").strip()
+        if not backend:
+            raise ValueError("LLM backend is not configured.")
+        model_name = config.get("MODEL")
+        server_url = config.get("LLM_ENDPOINT")
+        api_key = config.get("LLM_API_KEY")
+        return self.llm_client_factory.get_client(
+            backend=backend,
+            server_url=server_url,
+            model_name=model_name,
+            api_key=api_key,
+        )
+
+
+class AgentRuntimeClient:
+    """Facade that exposes sync streaming APIs for the Streamlit app."""
+
+    def __init__(self, orchestrator: AgentOrchestrator) -> None:
+        self._orchestrator = orchestrator
+
+    def stream_query(self, nl_query: str) -> Generator[OrchestratorEvent, None, None]:
+        """Yield orchestrator events as they become available."""
+        event_queue: "queue.Queue[Any]" = queue.Queue()
+        sentinel = object()
+
+        def runner() -> None:
+            async def produce() -> None:
+                try:
+                    async for event in self._orchestrator.run_nl_query_async(nl_query):
+                        event_queue.put(event)
+                except Exception as exc:  # pragma: no cover - defensive logging path
+                    logger.exception("Error while streaming orchestrator events")
+                    event_queue.put(exc)
+                finally:
+                    event_queue.put(sentinel)
+
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(produce())
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=runner, daemon=True)
+        thread.start()
+
+        while True:
+            item = event_queue.get()
+            if item is sentinel:
+                break
+            if isinstance(item, Exception):
+                raise item
+            yield item
+
+    def run_query(self, nl_query: str) -> List[OrchestratorEvent]:
+        return self._orchestrator.run_nl_query(nl_query)

--- a/agent_runtime/tool_registry.py
+++ b/agent_runtime/tool_registry.py
@@ -1,0 +1,54 @@
+"""Tool registry and database execution tools."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+import os
+
+from connectors.sql_alchemy import SqlAlchemy
+
+
+class ToolRegistry:
+    """Registry for orchestrator tools."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Any] = {}
+
+    def register(self, name: str, tool: Any) -> None:
+        self._tools[name] = tool
+
+    def get(self, name: str) -> Any:
+        if name not in self._tools:
+            raise KeyError(f"Tool '{name}' is not registered")
+        return self._tools[name]
+
+
+class SQLExecutionTool:
+    """Wrapper around a SQL connector used by the orchestrator."""
+
+    def __init__(self, connector_factory: Callable[[Dict[str, Any]], SqlAlchemy]):
+        self._connector_factory = connector_factory
+
+    def get_schema(self, config: Dict[str, Any]) -> str:
+        connector = self._connector_factory(config)
+        return connector.get_db_schema()
+
+    def run_query(self, config: Dict[str, Any], query: str) -> Any:
+        connector = self._connector_factory(config)
+        return connector.run_query(query)
+
+
+def _apply_env(config: Dict[str, Any]) -> None:
+    for key, value in config.items():
+        if value is None:
+            continue
+        os.environ[key] = str(value)
+
+
+def create_sqlalchemy_tool() -> SQLExecutionTool:
+    """Create a SQL execution tool backed by :class:`SqlAlchemy`."""
+
+    def factory(config: Dict[str, Any]) -> SqlAlchemy:
+        _apply_env(config)
+        return SqlAlchemy()
+
+    return SQLExecutionTool(factory)

--- a/db-agent.py
+++ b/db-agent.py
@@ -1,25 +1,29 @@
-import streamlit as st
-import pandas as pd
-from connectors.sql_alchemy import SqlAlchemy
-from textgen.factory import LLMClientFactory
-
-from helpers.query_history import * 
-from helpers.config_store import *
-from helpers.css_settings import *
-from helpers.dp_charts import *
-from helpers.supported_models import *
 import logging
-import time
-import os
+
+import pandas as pd
+import streamlit as st
 from dotenv import load_dotenv
+
+from agent_runtime import (
+    AgentOrchestrator,
+    AgentRuntimeClient,
+    ConfigService,
+    OrchestratorEventType,
+    ToolRegistry,
+    create_sqlalchemy_tool,
+)
+from helpers.config_store import load_from_env, save_to_env
+from helpers.css_settings import custom_css
+from helpers.query_history import display_query_history, load_query_history, save_query_history
+from helpers.supported_models import llm_backend, supported_models
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     handlers=[
-        logging.FileHandler("application.log"),  # Logs to a file
-        logging.StreamHandler()  # Logs to stdout
-    ]
+        logging.FileHandler("application.log"),
+        logging.StreamHandler(),
+    ],
 )
 
 logger = logging.getLogger(__name__)
@@ -27,146 +31,143 @@ logger.info("Logging initialized successfully!")
 
 load_dotenv()
 
-# st.set_page_config(page_title="DB Agent",page_icon="assets/logo.png")
-
-# Streamlit App Interface
 st.title("Talk to your DB in Natural Language")
-
 st.markdown(custom_css, unsafe_allow_html=True)
+
 with st.sidebar:
-    st.page_link('db-agent.py', label='DB Agent', icon='📊')
-    st.page_link('pages/ChatBot.py', label='Yet Another ChatBot', icon='🤖')
+    st.page_link("db-agent.py", label="DB Agent", icon="📊")
+    st.page_link("pages/ChatBot.py", label="Yet Another ChatBot", icon="🤖")
 
-
-
-
-# Initialize query history in session state
+# Initialize session state
 if "query_history" not in st.session_state:
     st.session_state["query_history"] = load_query_history()
 
 if "config" not in st.session_state:
     st.session_state["config"] = load_from_env()
 
+if "config_service" not in st.session_state:
+    st.session_state["config_service"] = ConfigService(st.session_state["config"])
+else:
+    st.session_state["config_service"].update(st.session_state["config"])
+
+if "tool_registry" not in st.session_state:
+    registry = ToolRegistry()
+    registry.register("sql", create_sqlalchemy_tool())
+    st.session_state["tool_registry"] = registry
+
+if "runtime_client" not in st.session_state:
+    orchestrator = AgentOrchestrator(
+        config_service=st.session_state["config_service"],
+        tool_registry=st.session_state["tool_registry"],
+    )
+    st.session_state["runtime_client"] = AgentRuntimeClient(orchestrator)
+
+config = st.session_state["config"]
+config_service: ConfigService = st.session_state["config_service"]
+runtime_client: AgentRuntimeClient = st.session_state["runtime_client"]
 
 with st.sidebar:
     with st.expander("Database Configuration"):
-        st.session_state.config = load_from_env()
         db_options = ["postgres", "mysql", "mssql", "oracle"]
+        current_driver = config.get("DB_DRIVER", db_options[0])
+        driver_index = db_options.index(current_driver) if current_driver in db_options else 0
+        config["DB_DRIVER"] = st.selectbox("SELECT DATABASE:", db_options, index=driver_index)
+        config["DB_HOST"] = st.text_input("DB_HOST:", value=config.get("DB_HOST", "") or "")
+        config["DB_PORT"] = st.text_input("DB_PORT:", value=config.get("DB_PORT", "") or "")
+        config["DB_USER"] = st.text_input("DB_USER:", value=config.get("DB_USER", "") or "")
+        config["DB_PASSWORD"] = st.text_input("DB_PASS:", value=config.get("DB_PASSWORD", "") or "")
+        config["DB_NAME"] = st.text_input("DB_NAME:", value=config.get("DB_NAME", "") or "")
 
-        st.session_state.config["DB_DRIVER"] = st.selectbox(
-            "SELECT DATABASE:", db_options,
-            db_options.index(st.session_state.config["DB_DRIVER"])
-        )
-        st.session_state.config["DB_HOST"] = st.text_input(
-            "DB_HOST:", st.session_state.config["DB_HOST"]
-        )
-        st.session_state.config["DB_PORT"] = st.text_input(
-            "DB_PORT:", st.session_state.config["DB_PORT"]
-        )
-        st.session_state.config["DB_USER"] = st.text_input(
-            "DB_USER:", st.session_state.config["DB_USER"]
-        )
-        st.session_state.config["DB_PASSWORD"] = st.text_input(
-            "DB_PASS:", st.session_state.config["DB_PASSWORD"]
-        )
-        st.session_state.config["DB_NAME"] = st.text_input(
-            "DB_NAME:", st.session_state.config["DB_NAME"]
-        )
-        
         if st.button("Save DB Config"):
-            save_to_env(st.session_state["config"])
+            save_to_env(config)
+            config_service.update(config)
             st.success("Database configuration saved!")
 
     with st.expander("Model Selection"):
-        st.session_state["config"] = load_from_env()
+        backend_default = config.get("LLM_BACKEND", llm_backend[0])
+        backend_index = llm_backend.index(backend_default) if backend_default in llm_backend else 0
+        config["LLM_BACKEND"] = st.selectbox("LLM_BACKEND:", llm_backend, index=backend_index)
 
-
-
-        # Dropdown to select the backend
-        st.session_state.config["LLM_BACKEND"] = st.selectbox(
-            "LLM_BACKEND:", 
-            llm_backend, 
-            index=llm_backend.index(st.session_state.config.get("LLM_BACKEND", llm_backend[0]))
-        )
-
-        # Dynamically update model options based on selected backend
-        selected_backend = st.session_state.config["LLM_BACKEND"]
+        selected_backend = config["LLM_BACKEND"]
         filtered_model_options = supported_models.get(selected_backend, [])
-
-        # Dropdown to select the model
-        st.session_state.config["MODEL"] = st.selectbox(
-            "SELECT Model:", 
-            filtered_model_options, 
-            index=filtered_model_options.index(st.session_state.config.get("MODEL", filtered_model_options[0])) 
-            if filtered_model_options else 0
+        if filtered_model_options:
+            model_default = config.get("MODEL", filtered_model_options[0])
+            model_index = (
+                filtered_model_options.index(model_default)
+                if model_default in filtered_model_options
+                else 0
+            )
+        else:
+            model_index = 0
+        config["MODEL"] = st.selectbox(
+            "SELECT Model:",
+            filtered_model_options or [""],
+            index=model_index,
         )
 
-        # Input for API key
-        st.session_state.config["LLM_API_KEY"] = st.text_input(
-            "API KEY:", 
-            value=st.session_state.config.get("LLM_API_KEY", "")
+        config["LLM_API_KEY"] = st.text_input(
+            "API KEY:",
+            value=config.get("LLM_API_KEY", "") or "",
         )
-        
-        # Input for LLM endpoint
-        st.session_state.config["LLM_ENDPOINT"] = st.text_input(
-            "LLM_ENDPOINT:", 
-            value=st.session_state.config.get("LLM_ENDPOINT", "")
+        config["LLM_ENDPOINT"] = st.text_input(
+            "LLM_ENDPOINT:",
+            value=config.get("LLM_ENDPOINT", "") or "",
         )
-        token_size = st.slider("Total Token", 1024, 2048, 4096)
-        
+        st.slider("Total Token", 1024, 2048, 4096, key="token_size")
+
         if st.button("Save LLM Config"):
-            save_to_env(st.session_state.config)
+            save_to_env(config)
+            config_service.update(config)
             st.success("LLM configuration saved!")
 
-        
     with st.expander("Show Database Schema"):
-        sql_alchemy = SqlAlchemy()
-        schema_info = sql_alchemy.get_db_schema()
-        st.text(schema_info)
+        try:
+            schema_tool = st.session_state["tool_registry"].get("sql")
+            schema_info = schema_tool.get_schema(config_service.get_config())
+            st.text(schema_info)
+        except Exception as exc:
+            st.error(f"Unable to load schema: {exc}")
 
-    
-
+config_service.update(config)
 
 nl_query = st.text_area("Ask a question about your data:")
+execute_pressed = st.button("▶️  Execute")
 
+if execute_pressed:
+    if nl_query.strip():
+        status_placeholder = st.empty()
+        sql_placeholder = st.empty()
+        meta_placeholder = st.empty()
+        result_placeholder = st.empty()
+        history_saved = False
 
-if st.button("▶️  Execute"):
-
-    if nl_query:
-        model_name=st.session_state.config.get("MODEL")
-        backend = st.session_state.config.get('LLM_BACKEND')
-
-
-        with st.spinner(f"Generating SQL Query using {model_name}"):
-            inference_client = LLMClientFactory.get_client(
-                backend = st.session_state.config.get('LLM_BACKEND'),
-                server_url = st.session_state.config.get('LLM_ENDPOINT'),
-                model_name = st.session_state.config.get("MODEL"),
-                api_key = st.session_state.config.get("LLM_API_KEY")
-            )
-        
-        sql_query=inference_client.generate_sql(nl_query,schema_info)
-
-        st.text(f"Generated SQL Query: LLM backend {backend} serving {model_name}")
-        st.code(sql_query, language="sql")
-
-        st.session_state.query_history.append((nl_query, sql_query))
-        save_query_history(st.session_state["query_history"])
-
-
-        with st.spinner(f"Executing SQL on {st.session_state.config['DB_DRIVER']}"):
-            query_result = sql_alchemy.run_query(sql_query)
-            if isinstance(query_result, str):
-                st.error(f"Error: {query_result}")
-            else:
-                st.success("Query executed successfully!")
-                if isinstance(query_result, pd.DataFrame) and not query_result.empty:
+        for event in runtime_client.stream_query(nl_query):
+            if event.type == OrchestratorEventType.STATUS:
+                status_placeholder.info(event.payload)
+            elif event.type == OrchestratorEventType.SQL:
+                backend = config.get("LLM_BACKEND") or config.get("LLM")
+                model_name = config.get("MODEL")
+                meta_placeholder.text(
+                    f"Generated SQL Query: LLM backend {backend} serving {model_name}"
+                )
+                sql_placeholder.code(event.payload, language="sql")
+                if not history_saved:
+                    st.session_state.query_history.append((nl_query, event.payload))
+                    save_query_history(st.session_state["query_history"])
+                    history_saved = True
+            elif event.type == OrchestratorEventType.RESULT:
+                status_placeholder.success("Query executed successfully!")
+                result = event.payload
+                if isinstance(result, pd.DataFrame) and not result.empty:
                     st.subheader("Query Results")
-                    st.dataframe(query_result)
-              
+                    result_placeholder.dataframe(result)
+                else:
+                    result_placeholder.write(result)
+            elif event.type == OrchestratorEventType.ERROR:
+                status_placeholder.error(event.payload)
+                break
     else:
         st.warning("Please enter a natural language query.")
-
 
 
 display_query_history()

--- a/helpers/config_store.py
+++ b/helpers/config_store.py
@@ -40,7 +40,3 @@ def load_from_env():
         "LLM_API_KEY": st.secrets.get("LLM_API_KEY"),
         "LLM_ENDPOINT": st.secrets.get("LLM_ENDPOINT"),
     }
-
-# Example usage
-config = load_from_env()
-st.write(config)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv
 kagglehub
 openai
 google-generativeai
+pytest

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,147 @@
+import pathlib
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agent_runtime import (
+    AgentOrchestrator,
+    AgentRuntimeClient,
+    ConfigService,
+    OrchestratorEventType,
+    ToolRegistry,
+)
+
+
+class DummyLLMClient:
+    def __init__(self, sql_text: str) -> None:
+        self.sql_text = sql_text
+        self.calls = []
+
+    def generate_sql(self, nl_query: str, schema: str) -> str:
+        self.calls.append((nl_query, schema))
+        return self.sql_text
+
+
+class DummyFactory:
+    def __init__(self, client: DummyLLMClient) -> None:
+        self.client = client
+
+    def get_client(self, **_: str) -> DummyLLMClient:  # type: ignore[override]
+        return self.client
+
+
+class RecordingTool:
+    def __init__(self, result):
+        self.result = result
+        self.schema_calls = 0
+        self.run_calls = []
+
+    def get_schema(self, config):
+        self.schema_calls += 1
+        self.last_config = config
+        return "table schema"
+
+    def run_query(self, config, query):
+        self.run_calls.append((config, query))
+        return self.result
+
+
+@pytest.fixture()
+def base_config():
+    return {
+        "LLM_BACKEND": "openai",
+        "MODEL": "gpt-4",
+        "LLM_ENDPOINT": "http://example",
+        "LLM_API_KEY": "token",
+        "DB_DRIVER": "postgres",
+        "DB_HOST": "localhost",
+    }
+
+
+def test_orchestrator_success_flow(base_config):
+    tool = RecordingTool(pd.DataFrame({"id": [1]}))
+    client = DummyLLMClient("SELECT * FROM table")
+    factory = DummyFactory(client)
+
+    registry = ToolRegistry()
+    registry.register("sql", tool)
+    orchestrator = AgentOrchestrator(
+        config_service=ConfigService(base_config),
+        tool_registry=registry,
+        llm_client_factory=factory,
+    )
+
+    events = orchestrator.run_nl_query("show records")
+
+    assert [event.type for event in events] == [
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.SQL,
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.RESULT,
+    ]
+    assert tool.schema_calls == 1
+    assert tool.run_calls[0][1] == "SELECT * FROM table"
+    assert orchestrator.memory.get_history()[0].sql == "SELECT * FROM table"
+
+
+def test_orchestrator_missing_tool_reports_error(base_config):
+    orchestrator = AgentOrchestrator(
+        config_service=ConfigService(base_config),
+        tool_registry=ToolRegistry(),
+        llm_client_factory=DummyFactory(DummyLLMClient("")),
+    )
+
+    events = orchestrator.run_nl_query("anything")
+
+    assert len(events) == 1
+    assert events[0].type == OrchestratorEventType.ERROR
+    assert "Tool" in events[0].payload
+
+
+def test_orchestrator_tool_error_surfaces_to_client(base_config):
+    tool = RecordingTool("Database error")
+    client = DummyLLMClient("SELECT 1")
+    factory = DummyFactory(client)
+
+    registry = ToolRegistry()
+    registry.register("sql", tool)
+
+    orchestrator = AgentOrchestrator(
+        config_service=ConfigService(base_config),
+        tool_registry=registry,
+        llm_client_factory=factory,
+    )
+
+    events = orchestrator.run_nl_query("show records")
+
+    assert events[-1].type == OrchestratorEventType.ERROR
+    assert events[-1].payload == "Database error"
+
+
+def test_runtime_client_streams_events_in_order(base_config):
+    tool = RecordingTool([{"value": 1}])
+    client = DummyLLMClient("SELECT value FROM table")
+    factory = DummyFactory(client)
+
+    registry = ToolRegistry()
+    registry.register("sql", tool)
+    orchestrator = AgentOrchestrator(
+        config_service=ConfigService(base_config),
+        tool_registry=registry,
+        llm_client_factory=factory,
+    )
+    runtime_client = AgentRuntimeClient(orchestrator)
+
+    streamed_types = [event.type for event in runtime_client.stream_query("give me value")]
+
+    assert streamed_types == [
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.SQL,
+        OrchestratorEventType.STATUS,
+        OrchestratorEventType.RESULT,
+    ]


### PR DESCRIPTION
## Summary
- add an agent runtime package with orchestrator, config service, memory, and tool registry modules
- refactor the Streamlit app to use the runtime client for streaming NL-to-SQL execution
- add pytest coverage for orchestrator decision paths and tool streaming behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f575ece038833396efe61857d795d8