### PR TITLE
Add structured LLM interfaces and adapters with legacy SQL fallback

### DIFF
--- a/agent_runtime/llm/__init__.py
+++ b/agent_runtime/llm/__init__.py
@@ -1,0 +1,14 @@
+"""LLM runtime interfaces and provider adapters."""
+
+from .interfaces import PlanStep, SQLDraft, PlanningInterface, ToolCallFormattingInterface, StreamingInterface
+from .base import LLMAdapter, LegacySQLWrapper
+
+__all__ = [
+    "PlanStep",
+    "SQLDraft",
+    "PlanningInterface",
+    "ToolCallFormattingInterface",
+    "StreamingInterface",
+    "LLMAdapter",
+    "LegacySQLWrapper",
+]

--- a/agent_runtime/llm/base.py
+++ b/agent_runtime/llm/base.py
@@ -1,0 +1,220 @@
+"""Base utilities for LLM provider adapters."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+import requests
+
+from .interfaces import PlanStep, SQLDraft, PlanningInterface, StreamingInterface, ToolCallFormattingInterface
+
+logger = logging.getLogger(__name__)
+
+
+PLAN_JSON_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "steps": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "summary": {"type": "string"},
+                    "details": {"type": "string"},
+                },
+                "required": ["id", "summary"],
+                "additionalProperties": False,
+            },
+        }
+    },
+    "required": ["steps"],
+    "additionalProperties": False,
+}
+
+SQL_JSON_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "statement": {"type": "string"},
+        "rationale": {"type": "string"},
+    },
+    "required": ["statement"],
+    "additionalProperties": False,
+}
+
+
+class LLMAdapter(PlanningInterface, ToolCallFormattingInterface, StreamingInterface, ABC):
+    """Base class providing utilities for provider specific adapters."""
+
+    def __init__(
+        self,
+        endpoint: Optional[str],
+        model: str,
+        api_key: Optional[str] = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self.endpoint = self._normalize_endpoint(endpoint)
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+        self._session = requests.Session()
+        logger.debug("Initialised %s for model=%s", self.__class__.__name__, self.model)
+
+    # ------------------------------------------------------------------
+    # Abstract hooks
+    # ------------------------------------------------------------------
+    @abstractmethod
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> Optional[str]:
+        """Return a provider specific endpoint from the configured value."""
+
+    @abstractmethod
+    def _build_chat_payload(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        """Return a payload suitable for a standard chat completion call."""
+
+    @abstractmethod
+    def _build_plan_payload(self, question: str, schema: Optional[str]) -> Dict[str, Any]:
+        """Return the payload used to request planning steps."""
+
+    @abstractmethod
+    def _build_sql_payload(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> Dict[str, Any]:
+        """Return the payload used to request a structured SQL draft."""
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def plan(self, question: str, schema: Optional[str] = None) -> List[PlanStep]:
+        payload = self._build_plan_payload(question, schema)
+        response = self._post_json(payload)
+        data = self._extract_json_object(response)
+        steps: List[PlanStep] = []
+        for index, raw_step in enumerate(data.get("steps", []), start=1):
+            step_id = int(raw_step.get("id", index))
+            summary = str(raw_step.get("summary", "")).strip()
+            details = raw_step.get("details")
+            steps.append(PlanStep(id=step_id, summary=summary, details=details))
+        return steps
+
+    def draft_sql(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> SQLDraft:
+        payload = self._build_sql_payload(question, schema, plan_steps)
+        response = self._post_json(payload)
+        data = self._extract_json_object(response)
+        statement = str(data.get("statement", "")).strip()
+        rationale = data.get("rationale")
+        if not statement:
+            raise ValueError("Model did not return a SQL statement in the structured response.")
+        return SQLDraft(statement=statement, rationale=rationale)
+
+    def generate_sql(self, question: str, schema: str) -> str:
+        """Compatibility wrapper for legacy callers expecting a SQL string."""
+
+        try:
+            plan_steps = self.plan(question, schema)
+            draft = self.draft_sql(question, schema, plan_steps)
+            return draft.statement
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Structured SQL generation failed, using legacy pathway.")
+            legacy_sql = self.legacy_generate_sql(question, schema)
+            if legacy_sql is None:
+                raise
+            return legacy_sql
+
+    def format_tool_call(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        return {"type": "function", "function": {"name": name, "arguments": json.dumps(arguments)}}
+
+    def stream(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Iterable[str]:
+        payload = self._build_chat_payload(messages, **kwargs)
+        response = self._post_json(payload)
+        content = self._extract_message_content(response)
+        if content:
+            yield content
+
+    # ------------------------------------------------------------------
+    # Fallback hooks
+    # ------------------------------------------------------------------
+    def legacy_generate_sql(self, question: str, schema: str) -> Optional[str]:
+        """Override to provide a provider specific legacy SQL path."""
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Networking helpers
+    # ------------------------------------------------------------------
+    def _post_json(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not self.endpoint:
+            raise RuntimeError("No endpoint configured for HTTP based provider.")
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        logger.debug("POST %s payload=%s", self.endpoint, payload)
+        response = self._session.post(
+            self.endpoint,
+            headers=headers,
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+    def _extract_message_content(self, payload: Dict[str, Any]) -> Optional[str]:
+        choice = (payload or {}).get("choices", [{}])[0]
+        message = choice.get("message", {})
+        content = message.get("content")
+        if isinstance(content, list):  # OpenAI style content array
+            return "".join(
+                part.get("text", "") if isinstance(part, dict) else str(part) for part in content
+            )
+        return content
+
+    def _extract_json_object(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        raw_content = self._extract_message_content(payload)
+        if isinstance(raw_content, dict):
+            return raw_content
+        if not raw_content:
+            return {}
+        try:
+            return json.loads(raw_content)
+        except json.JSONDecodeError as exc:  # pragma: no cover - depends on provider outputs
+            raise ValueError("Expected JSON object in response content") from exc
+
+    @staticmethod
+    def extract_sql_statement(text: str) -> Optional[str]:
+        sql_pattern = re.compile(r"(?is)\bselect\b.*?\bfrom\b.*?(?:;|$)")
+        match = sql_pattern.search(text)
+        return match.group(0).strip() if match else None
+
+
+class LegacySQLWrapper:
+    """Wrap an adapter to expose the legacy :py:meth:`generate_sql` API."""
+
+    def __init__(self, adapter: LLMAdapter, fallback: Optional[Any] = None) -> None:
+        self._adapter = adapter
+        self._fallback = fallback
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - passthrough
+        return getattr(self._adapter, item)
+
+    def generate_sql(self, question: str, schema: str) -> str:
+        try:
+            return self._adapter.generate_sql(question, schema)
+        except Exception:  # pragma: no cover - defensive fallback
+            if self._fallback is None:
+                raise
+            logger.exception("Adapter generate_sql failed; using supplied fallback callable.")
+            return self._fallback(question, schema)

--- a/agent_runtime/llm/gemini.py
+++ b/agent_runtime/llm/gemini.py
@@ -1,0 +1,175 @@
+"""Google Gemini adapter implementation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from .base import LLMAdapter, PLAN_JSON_SCHEMA, SQL_JSON_SCHEMA
+from .interfaces import PlanStep, SQLDraft
+
+try:  # pragma: no cover - optional dependency at runtime
+    import google.generativeai as genai
+    from google.generativeai.types import GenerationConfig
+except Exception:  # pragma: no cover - defensive import
+    genai = None  # type: ignore[assignment]
+    GenerationConfig = Any  # type: ignore[misc]
+
+logger = logging.getLogger(__name__)
+
+
+class GeminiAdapter(LLMAdapter):
+    """Adapter that relies on the Google Generative AI Python SDK."""
+
+    def __init__(self, endpoint: Optional[str], model: str, api_key: Optional[str] = None, timeout: float = 60.0) -> None:
+        super().__init__(endpoint, model, api_key, timeout)
+        if genai is None:
+            raise RuntimeError("google-generativeai package is required for GeminiAdapter")
+        if api_key:
+            genai.configure(api_key=api_key)
+        self._model = genai.GenerativeModel(model_name=model)
+
+    # ------------------------------------------------------------------
+    # Abstract implementations (unused by Gemini, but required by ABC)
+    # ------------------------------------------------------------------
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> Optional[str]:
+        return endpoint
+
+    def _build_chat_payload(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:  # pragma: no cover
+        raise NotImplementedError("GeminiAdapter does not use HTTP chat payloads")
+
+    def _build_plan_payload(self, question: str, schema: Optional[str]) -> Dict[str, Any]:  # pragma: no cover
+        raise NotImplementedError("GeminiAdapter does not use HTTP plan payloads")
+
+    def _build_sql_payload(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> Dict[str, Any]:  # pragma: no cover
+        raise NotImplementedError("GeminiAdapter does not use HTTP sql payloads")
+
+    # ------------------------------------------------------------------
+    # Gemini specific overrides
+    # ------------------------------------------------------------------
+    def plan(self, question: str, schema: Optional[str] = None) -> List[PlanStep]:
+        prompt = "Plan the steps necessary to answer the question before writing SQL."
+        payload = {"question": question, "schema": schema}
+        generation_config = GenerationConfig(  # type: ignore[call-arg]
+            temperature=0,
+            response_mime_type="application/json",
+            response_schema=PLAN_JSON_SCHEMA,
+        )
+        logger.debug("Gemini plan prompt payload=%s", payload)
+        response = self._model.generate_content(
+            [prompt, json.dumps(payload)],
+            generation_config=generation_config,
+        )
+        data = self._parse_json_text(response)
+        steps: List[PlanStep] = []
+        for index, raw_step in enumerate(data.get("steps", []), start=1):
+            step_id = int(raw_step.get("id", index))
+            steps.append(
+                PlanStep(
+                    id=step_id,
+                    summary=str(raw_step.get("summary", "")).strip(),
+                    details=raw_step.get("details"),
+                )
+            )
+        return steps
+
+    def draft_sql(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> SQLDraft:
+        payload = {
+            "question": question,
+            "schema": schema,
+            "plan": [
+                {"id": step.id, "summary": step.summary, "details": step.details}
+                for step in plan_steps or []
+            ],
+        }
+        generation_config = GenerationConfig(  # type: ignore[call-arg]
+            temperature=0,
+            response_mime_type="application/json",
+            response_schema=SQL_JSON_SCHEMA,
+        )
+        logger.debug("Gemini sql prompt payload=%s", payload)
+        response = self._model.generate_content(
+            [
+                "Produce a SQL draft for the provided question and schema in JSON format.",
+                json.dumps(payload),
+            ],
+            generation_config=generation_config,
+        )
+        data = self._parse_json_text(response)
+        statement = str(data.get("statement", "")).strip()
+        rationale = data.get("rationale")
+        if not statement:
+            raise ValueError("Gemini response did not contain a SQL statement")
+        return SQLDraft(statement=statement, rationale=rationale)
+
+    def generate_sql(self, question: str, schema: str) -> str:
+        try:
+            steps = self.plan(question, schema)
+            draft = self.draft_sql(question, schema, steps)
+            return draft.statement
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Gemini structured SQL generation failed; using legacy path.")
+            legacy = self.legacy_generate_sql(question, schema)
+            if legacy is None:
+                raise
+            return legacy
+
+    def stream(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Iterable[str]:
+        logger.debug("Gemini streaming with %d messages", len(messages))
+        stream = self._model.generate_content(messages, stream=True, **kwargs)
+        for chunk in stream:
+            text = getattr(chunk, "text", None) or "".join(
+                getattr(part, "text", "") for part in getattr(chunk, "parts", [])
+            )
+            if text:
+                yield text
+
+    # ------------------------------------------------------------------
+    # Legacy fallback
+    # ------------------------------------------------------------------
+    def legacy_generate_sql(self, question: str, schema: str) -> Optional[str]:
+        prompt = (
+            f"Generate a SQL query only to answer this question without explanation: `{question}`\n"
+            f"DDL statements:\n{schema}\n"
+        )
+        try:
+            response = self._model.generate_content(prompt)
+            text = getattr(response, "text", None)
+            if not text and getattr(response, "candidates", None):
+                text = "".join(
+                    getattr(part, "text", "")
+                    for candidate in response.candidates
+                    for part in getattr(candidate.content, "parts", [])
+                )
+            if not text:
+                return None
+            return self.extract_sql_statement(text)
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Gemini legacy SQL generation failed.")
+            return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _parse_json_text(self, response: Any) -> Dict[str, Any]:
+        text = getattr(response, "text", None)
+        if not text and getattr(response, "candidates", None):
+            text = "".join(
+                getattr(part, "text", "")
+                for candidate in response.candidates
+                for part in getattr(candidate.content, "parts", [])
+            )
+        if not text:
+            return {}
+        return json.loads(text)

--- a/agent_runtime/llm/huggingface.py
+++ b/agent_runtime/llm/huggingface.py
@@ -1,0 +1,109 @@
+"""HuggingFace Text Generation Inference adapter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+from .base import LLMAdapter, PLAN_JSON_SCHEMA, SQL_JSON_SCHEMA
+from .interfaces import PlanStep
+
+logger = logging.getLogger(__name__)
+
+
+class HuggingFaceAdapter(LLMAdapter):
+    """Adapter for HuggingFace Text Generation Inference deployments."""
+
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> Optional[str]:
+        if endpoint is None:
+            return None
+        endpoint = endpoint.rstrip("/")
+        if not endpoint.startswith("http"):
+            endpoint = f"http://{endpoint}"
+        if not endpoint.endswith("/v1/chat/completions"):
+            endpoint = f"{endpoint}/v1/chat/completions"
+        return endpoint
+
+    def _build_chat_payload(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": list(messages),
+            "temperature": kwargs.get("temperature", 0.7),
+            "max_new_tokens": kwargs.get("max_new_tokens", 512),
+        }
+        payload.update({k: v for k, v in kwargs.items() if k not in payload})
+        return payload
+
+    def _build_plan_payload(self, question: str, schema: Optional[str]) -> Dict[str, Any]:
+        system_prompt = "Plan the work before writing SQL. Return JSON only."
+        user_payload = {
+            "question": question,
+            "schema": schema,
+        }
+        return {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": json.dumps(user_payload)},
+            ],
+            "temperature": 0,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "plan_response",
+                    "schema": PLAN_JSON_SCHEMA,
+                },
+            },
+        }
+
+    def _build_sql_payload(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "question": question,
+            "schema": schema,
+            "plan": [
+                {"id": step.id, "summary": step.summary, "details": step.details}
+                for step in plan_steps or []
+            ],
+        }
+        return {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Only return valid JSON describing the SQL draft.",
+                },
+                {"role": "user", "content": json.dumps(payload)},
+            ],
+            "temperature": 0,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "sql_draft", "schema": SQL_JSON_SCHEMA},
+            },
+        }
+
+    def legacy_generate_sql(self, question: str, schema: str) -> Optional[str]:
+        prompt = (
+            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+            f"Generate a SQL query only to answer this question without explanation: `{question}`\n"
+            "DDL statements:\n"
+            f"{schema}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        )
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+            "stream": False,
+        }
+        try:
+            response = self._post_json(payload)
+            text = self._extract_message_content(response) or ""
+            return self.extract_sql_statement(text)
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Legacy SQL generation failed for HuggingFace adapter.")
+            return None

--- a/agent_runtime/llm/interfaces.py
+++ b/agent_runtime/llm/interfaces.py
@@ -1,0 +1,46 @@
+"""Core interfaces for large language model orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence
+
+
+@dataclass
+class PlanStep:
+    """Represents a single planning step returned by a model."""
+
+    id: int
+    summary: str
+    details: Optional[str] = None
+
+
+@dataclass
+class SQLDraft:
+    """Represents a structured SQL draft returned by a model."""
+
+    statement: str
+    rationale: Optional[str] = None
+
+
+class PlanningInterface(Protocol):
+    """Interface for models capable of returning multi-step plans."""
+
+    def plan(self, question: str, schema: Optional[str] = None) -> List[PlanStep]:
+        """Return an ordered list of planning steps for the provided question."""
+
+
+class ToolCallFormattingInterface(Protocol):
+    """Interface for models that format tool calls."""
+
+    def format_tool_call(self, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Format a tool invocation payload according to the provider contract."""
+
+
+class StreamingInterface(Protocol):
+    """Interface for models that support streaming responses."""
+
+    def stream(
+        self, messages: Sequence[Dict[str, Any]], **kwargs: Any
+    ) -> Iterable[str]:
+        """Yield chunks of assistant text for the provided chat messages."""

--- a/agent_runtime/llm/ollama.py
+++ b/agent_runtime/llm/ollama.py
@@ -1,0 +1,108 @@
+"""Ollama chat completions adapter."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+from .base import LLMAdapter, PLAN_JSON_SCHEMA, SQL_JSON_SCHEMA
+from .interfaces import PlanStep
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaAdapter(LLMAdapter):
+    """Adapter for the Ollama HTTP API."""
+
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> Optional[str]:
+        if endpoint is None:
+            return None
+        endpoint = endpoint.rstrip("/")
+        if not endpoint.startswith("http"):
+            endpoint = f"http://{endpoint}"
+        if not endpoint.endswith("/api/chat"):
+            endpoint = f"{endpoint}/api/chat"
+        return endpoint
+
+    def _build_chat_payload(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": list(messages),
+            "stream": False,
+        }
+        payload.update(kwargs)
+        return payload
+
+    def _build_plan_payload(self, question: str, schema: Optional[str]) -> Dict[str, Any]:
+        user_payload = {
+            "question": question,
+            "schema": schema,
+        }
+        system_prompt = "Plan the answer in JSON before writing SQL."
+        return {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": json.dumps(user_payload)},
+            ],
+            "stream": False,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "plan_response", "schema": PLAN_JSON_SCHEMA},
+            },
+        }
+
+    def _build_sql_payload(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> Dict[str, Any]:
+        payload = {
+            "question": question,
+            "schema": schema,
+            "plan": [
+                {"id": step.id, "summary": step.summary, "details": step.details}
+                for step in plan_steps or []
+            ],
+        }
+        return {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "Return JSON with a SQL statement under the 'statement' key.",
+                },
+                {"role": "user", "content": json.dumps(payload)},
+            ],
+            "stream": False,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {"name": "sql_draft", "schema": SQL_JSON_SCHEMA},
+            },
+        }
+
+    def legacy_generate_sql(self, question: str, schema: str) -> Optional[str]:
+        prompt = (
+            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+            f"Generate a SQL query only to answer this question without explanation: `{question}`\n"
+            "considering values like true,TRUE,yes,Yes,YES in a case-insensitive manner.\n"
+            "considering values like false,FALSE,no,No,NO in a case-insensitive manner.\n"
+            "DDL statements:\n"
+            f"{schema}<|start_header_id|>assistant<|end_header_id|>\n\n"
+        )
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+            "temperature": 0,
+        }
+        try:
+            response = self._post_json(payload)
+            message = (response or {}).get("message", {})
+            text = message.get("content") or self._extract_message_content(response) or ""
+            return self.extract_sql_statement(text)
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Legacy SQL generation failed for Ollama adapter.")
+            return None

--- a/agent_runtime/llm/openai.py
+++ b/agent_runtime/llm/openai.py
@@ -1,0 +1,115 @@
+"""OpenAI-compatible adapter implementation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Sequence
+
+from .base import LLMAdapter, PLAN_JSON_SCHEMA, SQL_JSON_SCHEMA
+from .interfaces import PlanStep
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIAdapter(LLMAdapter):
+    """Adapter for OpenAI compatible chat completions endpoints."""
+
+    def _normalize_endpoint(self, endpoint: Optional[str]) -> Optional[str]:
+        if endpoint is None:
+            return None
+        endpoint = endpoint.rstrip("/")
+        if endpoint.startswith("http"):
+            base = endpoint
+        else:
+            base = f"http://{endpoint}"
+        if not base.endswith("/v1/chat/completions"):
+            base = f"{base}/v1/chat/completions"
+        return base
+
+    def _build_chat_payload(self, messages: Sequence[Dict[str, Any]], **kwargs: Any) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": list(messages),
+        }
+        payload.update(kwargs)
+        return payload
+
+    def _build_plan_payload(self, question: str, schema: Optional[str]) -> Dict[str, Any]:
+        system_prompt = (
+            "You are an expert SQL planner. Break the task into numbered steps before writing SQL."
+        )
+        user_prompt = {
+            "role": "user",
+            "content": json.dumps({
+                "question": question,
+                "schema": schema,
+            }),
+        }
+        return {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                user_prompt,
+            ],
+            "temperature": 0,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "plan_response",
+                    "schema": PLAN_JSON_SCHEMA,
+                },
+            },
+        }
+
+    def _build_sql_payload(
+        self,
+        question: str,
+        schema: str,
+        plan_steps: Optional[List[PlanStep]] = None,
+    ) -> Dict[str, Any]:
+        plan_payload = [
+            {"id": step.id, "summary": step.summary, "details": step.details}
+            for step in plan_steps or []
+        ]
+        system_prompt = "You are a careful SQL assistant that only returns syntactically valid SQL."
+        user_payload = {
+            "question": question,
+            "schema": schema,
+            "plan": plan_payload,
+        }
+        return {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": json.dumps(user_payload)},
+            ],
+            "temperature": 0,
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "sql_draft",
+                    "schema": SQL_JSON_SCHEMA,
+                },
+            },
+        }
+
+    def legacy_generate_sql(self, question: str, schema: str) -> Optional[str]:
+        prompt = (
+            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+            f"Generate a SQL query only to answer this question without explanation: `{question}`\n"
+            "DDL statements:\n"
+            f"{schema}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+        )
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0,
+        }
+        try:
+            response = self._post_json(payload)
+            text = self._extract_message_content(response) or ""
+            return self.extract_sql_statement(text)
+        except Exception:  # pragma: no cover - defensive fallback
+            logger.exception("Legacy SQL generation failed for OpenAI adapter.")
+            return None

--- a/textgen/base.py
+++ b/textgen/base.py
@@ -1,84 +1,14 @@
-import re
-import requests
-import logging
-from abc import ABC, abstractmethod
+"""Legacy interfaces retained for backward compatibility."""
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from __future__ import annotations
 
-class TextGenBase(ABC):
-    """
-    Abstract base class for text generation clients.
-    """
+from agent_runtime.llm.base import LLMAdapter
 
-    def __init__(self, server_url, model_name,api_key=None):
-        self.server_url = self.override_server_url(server_url)
-        self.model_name = model_name
-        self.api_key = api_key
-        logger.info(f"Initialized {self.__class__.__name__} with server_url={self.server_url} and model_name={self.model_name}")
 
-    def override_server_url(self, server_url):
-        """
-        Override server URL in subclasses if necessary.
-        """
-        return server_url
+class TextGenBase(LLMAdapter):
+    """Deprecated alias of :class:`agent_runtime.llm.base.LLMAdapter`."""
 
-    @abstractmethod
-    def construct_sql_payload(self, user_question, db_schema):
-        pass
+    def __init__(self, server_url, model_name, api_key=None, timeout: float = 60.0):
+        super().__init__(server_url, model_name, api_key, timeout)
 
-    @abstractmethod
-    def construct_generic_payload(self, user_question, db_schema):
-        pass
-
-    @abstractmethod
-    def parse_response(self, response):
-        pass
-
-    def generate_generic_response(self, user_question):
-        try:
-            payload = self.construct_generic_payload(user_question)
-            headers = {"Content-Type": "application/json"}
-            logging.info(f"Sending Payload: {payload} to Server: {self.server_url}")
-            response = requests.post(self.server_url, headers=headers, json=payload)
-            response.raise_for_status()
-            raw_response = response.json()
-            return self.parse_response(raw_response)
-        except requests.exceptions.RequestException as e:
-            error_response = None
-            if hasattr(e.response, "text"):  # Check if the response object exists
-                error_response = e.response.text
-            error_message = f"Error: {e}.\n Response: {error_response}"
-            logging.error(error_message)  # Log the error for debugging purposes
-            return error_message
-        
-  
-
-    def generate_sql(self, user_question, db_schema):
-        try:
-            payload = self.construct_sql_payload(user_question, db_schema)
-            headers = {"Content-Type": "application/json"}
-            response = requests.post(self.server_url, headers=headers, json=payload)
-            response.raise_for_status()
-            raw_response = response.json()
-            return self._extract_sql_statement(self.parse_response(raw_response))
-        except requests.exceptions.RequestException as e:
-            error_response = None
-            if hasattr(e.response, "text"):  # Check if the response object exists
-                error_response = e.response.text
-            error_message = f"Error: {e}.\n Response: {error_response}"
-            logging.error(error_message)  # Log the error for debugging purposes
-            return error_message
-        
-    
-    
-
-    @staticmethod
-    def _extract_sql_statement(input_string):
-        sql_pattern = re.compile(
-            r"(?i)\bSELECT\b.*?\bFROM\b.*?(?:;|$)",  # Matches SQL statements starting with SELECT and containing FROM
-            re.DOTALL
-        )
-        match = sql_pattern.search(input_string)
-        return match.group(0).strip() if match else None
+    # LLMAdapter already implements the required behaviour.

--- a/textgen/factory.py
+++ b/textgen/factory.py
@@ -1,19 +1,28 @@
-from .huggingface import HuggingFaceClient
-from .ollama import OllamaClient
-from .openai_client import OpenAIClient
-from .google_gemini import GoogleGeminiClient
+"""Factory for instantiating provider specific LLM adapters."""
+
+from __future__ import annotations
+
+from agent_runtime.llm.base import LegacySQLWrapper
+from agent_runtime.llm.huggingface import HuggingFaceAdapter
+from agent_runtime.llm.ollama import OllamaAdapter
+from agent_runtime.llm.openai import OpenAIAdapter
+from agent_runtime.llm.gemini import GeminiAdapter
+
 
 class LLMClientFactory:
+    """Instantiate LLM adapters for the configured backend."""
+
     @staticmethod
-    def get_client(backend, server_url, model_name,api_key):
-        backend = backend.lower()
+    def get_client(backend, server_url, model_name, api_key):
+        backend = (backend or "").lower()
         if backend == "huggingface":
-            return HuggingFaceClient(server_url, model_name)
+            adapter = HuggingFaceAdapter(server_url, model_name, api_key)
         elif backend == "ollama":
-            return OllamaClient(server_url, model_name)
+            adapter = OllamaAdapter(server_url, model_name, api_key)
         elif backend == "openai":
-            return OpenAIClient(server_url,model_name)
+            adapter = OpenAIAdapter(server_url, model_name, api_key)
         elif backend == "gemini":
-            return GoogleGeminiClient(server_url,model_name,api_key)
+            adapter = GeminiAdapter(server_url, model_name, api_key)
         else:
             raise ValueError(f"Unsupported LLM backend: {backend}")
+        return LegacySQLWrapper(adapter)

--- a/textgen/google_gemini.py
+++ b/textgen/google_gemini.py
@@ -1,36 +1,5 @@
-from .base import TextGenBase
-import logging
-import google.generativeai as genai
+"""Backward compatible import for Google Gemini adapter."""
 
-logger = logging.getLogger(__name__)
+from agent_runtime.llm.gemini import GeminiAdapter as GoogleGeminiClient
 
-class GoogleGeminiClient(TextGenBase):
-
-    def construct_sql_payload(self, user_question, db_schema):
-        prompt = \
-            f"Generate a SQL query only to answer this question without explanation and without code formatting for markdown: `{user_question}`\n"\
-            f"DDL statements:\n"\
-            f"{db_schema}\n"
-        
-        return prompt
-    
-    def construct_generic_payload(self, user_question):
-        return user_question
-
-    def generate_sql(self, user_question, db_schema):
-        genai.configure(api_key=self.api_key)
-        model = genai.GenerativeModel(self.model_name)
-        response = model.generate_content(self.construct_sql_payload(user_question,db_schema))
-        return self.parse_response(response)
-    
-    def generate_generic_response(self, user_question):
-        genai.configure(api_key=self.api_key)
-        model = genai.GenerativeModel(self.model_name)
-        response = model.generate_content(user_question)
-        return self.parse_response(response)
-                
-
-    def parse_response(self, response):
-        logger.info(f"Parsing response of {self.model_name} with Google Gemini")
-        return response.text
-        
+__all__ = ["GoogleGeminiClient"]

--- a/textgen/huggingface.py
+++ b/textgen/huggingface.py
@@ -1,41 +1,5 @@
-from .base import TextGenBase
-import logging
+"""Backward compatible import for HuggingFace adapter."""
 
-logger = logging.getLogger(__name__)
+from agent_runtime.llm.huggingface import HuggingFaceAdapter as HuggingFaceClient
 
-class HuggingFaceClient(TextGenBase):
-    def override_server_url(self, server_url):
-        logger.info("Overriding server URL for HuggingFace")
-        return f"http://{server_url}/v1/chat/completions"
-
-    def construct_sql_payload(self, user_question, db_schema):
-        prompt = (
-            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
-            f"Generate a SQL query only to answer this question without explanation: `{user_question}`\n"
-            "DDL statements:\n"
-            f"{db_schema}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
-        return {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0
-        }
-    
-    def construct_generic_payload(self, user_question):
-        prompt = user_question
-        return {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0.7,
-            "max_new_tokens": 4096,
-            "max_length": 4096,
-            "top_p": 0.9,
-            "repetition_penalty": 1.1,
-            "stream": False,
-            "max_tokens": 1024
-
-        }
-
-    def parse_response(self, response):
-        logger.info(f"Parsing response of {self.model_name} with TGI")
-        return response.get("choices", [{}])[0].get("message", {}).get("content", "No response")
+__all__ = ["HuggingFaceClient"]

--- a/textgen/ollama.py
+++ b/textgen/ollama.py
@@ -1,44 +1,5 @@
-from .base import TextGenBase
-import logging
+"""Backward compatible import for Ollama adapter."""
 
-logger = logging.getLogger(__name__)
+from agent_runtime.llm.ollama import OllamaAdapter as OllamaClient
 
-class OllamaClient(TextGenBase):
-    def override_server_url(self, server_url):
-        logger.info("Overriding server URL for Ollama")
-        return f"http://{server_url}/api/chat"
-
-    def construct_sql_payload(self, user_question, db_schema):
-        logger.info("Constructing payload for Ollama")
-        prompt = (
-            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
-            f"Generate a SQL query only to answer this question without explanation: `{user_question}`\n"
-            "considering values like true,TRUE,yes,Yes,YES in a case-insensitive manner.\n"
-            "considering values like false,FALSE,no,No,NO in a case-insensitive manner.\n"
-            "DDL statements:\n"
-            f"{db_schema}<|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
-        return {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": False,
-            "temperature": 0
-        }
-    def construct_generic_payload(self, user_question):
-        prompt = user_question
-        return {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0.7,
-            "max_new_tokens": 4096,
-            "max_length": 4096,
-            "top_p": 0.9,
-            "repetition_penalty": 1.1,
-            "stream": False,
-            "max_tokens": 1024
-
-        }
-        
-    def parse_response(self, response):
-        logger.info(f"Parsing response for Ollama {response}")
-        return response.get('message', {}).get('content', '').strip()
+__all__ = ["OllamaClient"]

--- a/textgen/openai_client.py
+++ b/textgen/openai_client.py
@@ -1,45 +1,5 @@
-from openai import OpenAI
-from .base import TextGenBase
-import logging
+"""Backward compatible import for OpenAI adapter."""
 
-logger = logging.getLogger(__name__)
+from agent_runtime.llm.openai import OpenAIAdapter as OpenAIClient
 
-
-class OpenAIClient:
-    def override_server_url(self, server_url):
-        logger.info("Overriding server URL for HuggingFace")
-        server_url= f"http://{server_url}/v1/"
-        self.client = OpenAI(
-            base_url=server_url,
-            api_key="-"
-        )
-        return server_url
-
-    def construct_sql_payload(self, user_question, db_schema):
-        prompt = (
-            "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
-            f"Generate a SQL query only to answer this question without explanation: `{user_question}`\n"
-            "DDL statements:\n"
-            f"{db_schema}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
-        )
-        return {
-            "model": self.model_name,
-            "messages": [{"role": "user", "content": prompt}],
-            "temperature": 0
-        }
-    
-    def construct_generic_payload(self, user_question):
-        chat_completion = self.client.chat.completions.create(
-            model="meta-llama/Llama-3.2-1B-Instruct",
-            messages=[
-                {"role": "user", "content": user_question}
-            ],
-            stream=False,
-            max_tokens=1024,  # Maximum number of tokens to generate
-            temperature=0.7,  # Adds randomness to encourage a longer response
-            top_p=0.9         # Ensures diverse token sampling
-        )
-
-    def parse_response(self, response):
-        logger.info(f"Parsing response of {self.model_name} with TGI")
-        return response.get("choices", [{}])[0].get("message", {}).get("content", "No response")
+__all__ = ["OpenAIClient"]


### PR DESCRIPTION
## Summary
- introduce planning, tool call formatting, and streaming interfaces plus a base adapter with shared JSON schema helpers
- add OpenAI, Gemini, HuggingFace, and Ollama provider adapters that emit structured plan and SQL draft responses while preserving legacy fallbacks
- update textgen factory and shims to construct the new adapters and expose the traditional `generate_sql` entrypoint

## Testing
- python -m compileall agent_runtime textgen

------
https://chatgpt.com/codex/tasks/task_b_68f5827c09f483338ba942feb0f732ed