### PR TITLE
Add MCP server with registered runtime tools

### DIFF
--- a/agent_runtime/__init__.py
+++ b/agent_runtime/__init__.py
@@ -3,7 +3,8 @@
 from .orchestrator import AgentOrchestrator, AgentRuntimeClient, OrchestratorEvent, OrchestratorEventType
 from .config_service import ConfigService
 from .memory import ConversationMemory
-from .tool_registry import ToolRegistry, SQLExecutionTool, create_sqlalchemy_tool
+from .tool_registry import ToolDefinition, ToolRegistry, SQLExecutionTool, create_sqlalchemy_tool
+from .tools import register_default_tools
 
 __all__ = [
     "AgentOrchestrator",
@@ -12,7 +13,9 @@ __all__ = [
     "OrchestratorEventType",
     "ConfigService",
     "ConversationMemory",
+    "ToolDefinition",
     "ToolRegistry",
     "SQLExecutionTool",
     "create_sqlalchemy_tool",
+    "register_default_tools",
 ]

--- a/agent_runtime/tool_registry.py
+++ b/agent_runtime/tool_registry.py
@@ -1,25 +1,69 @@
 """Tool registry and database execution tools."""
 from __future__ import annotations
 
-from typing import Any, Callable, Dict
+import inspect
 import os
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, cast
 
 from connectors.sql_alchemy import SqlAlchemy
 
 
+@dataclass
+class ToolDefinition:
+    """Description and runtime hook for a tool exposed to MCP clients."""
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+    output_schema: Dict[str, Any]
+    handler: Callable[[Dict[str, Any]], Any | Awaitable[Any]]
+
+    async def invoke(self, arguments: Optional[Dict[str, Any]] = None) -> Any:
+        """Execute the tool handler with optional arguments."""
+
+        payload = arguments or {}
+        result = self.handler(payload)
+        if inspect.isawaitable(result):
+            result = await cast(Awaitable[Any], result)
+        return result
+
+    def to_protocol_dict(self) -> Dict[str, Any]:
+        """Return the MCP protocol representation of the tool."""
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema,
+            "outputSchema": self.output_schema,
+        }
+
+
 class ToolRegistry:
-    """Registry for orchestrator tools."""
+    """Registry for orchestrator tools and MCP tool definitions."""
 
     def __init__(self) -> None:
         self._tools: Dict[str, Any] = {}
+        self._definitions: Dict[str, ToolDefinition] = {}
 
     def register(self, name: str, tool: Any) -> None:
         self._tools[name] = tool
+
+    def register_definition(self, definition: ToolDefinition) -> None:
+        self._definitions[definition.name] = definition
 
     def get(self, name: str) -> Any:
         if name not in self._tools:
             raise KeyError(f"Tool '{name}' is not registered")
         return self._tools[name]
+
+    def get_definition(self, name: str) -> ToolDefinition:
+        if name not in self._definitions:
+            raise KeyError(f"Tool definition '{name}' is not registered")
+        return self._definitions[name]
+
+    def definitions(self) -> Iterable[ToolDefinition]:
+        return self._definitions.values()
 
 
 class SQLExecutionTool:

--- a/agent_runtime/tools.py
+++ b/agent_runtime/tools.py
@@ -1,0 +1,214 @@
+"""Tool definition helpers for the agent runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .config_service import ConfigService
+from .tool_registry import (
+    SQLExecutionTool,
+    ToolDefinition,
+    ToolRegistry,
+    create_sqlalchemy_tool,
+)
+
+try:  # pragma: no cover - pandas is optional at runtime
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - pandas is optional at runtime
+    pd = None  # type: ignore
+
+
+@dataclass
+class _SchemaInspectionHandler:
+    config_service: ConfigService
+    sql_tool: SQLExecutionTool
+
+    def __call__(self, _: Mapping[str, Any]) -> Dict[str, Any]:
+        config = self.config_service.get_config()
+        if not config:
+            raise RuntimeError("Runtime configuration is empty.")
+        schema = self.sql_tool.get_schema(config)
+        return {"schema": schema}
+
+
+@dataclass
+class _RunSQLHandler:
+    config_service: ConfigService
+    sql_tool: SQLExecutionTool
+
+    def __call__(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        query = params.get("sql") or params.get("query")
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError("The 'sql' parameter must be a non-empty string.")
+
+        config = self.config_service.get_config()
+        if not config:
+            raise RuntimeError("Runtime configuration is empty.")
+
+        result = self.sql_tool.run_query(config, query)
+        if isinstance(result, str):
+            raise RuntimeError(result)
+
+        rows, columns = _normalize_tabular_result(result)
+        return {"rows": rows, "columns": columns}
+
+
+@dataclass
+class _SummarizeResultsHandler:
+    def __call__(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        rows = params.get("rows")
+        columns = params.get("columns")
+
+        if not isinstance(rows, Sequence):
+            rows = []
+        if not isinstance(columns, Sequence):
+            columns = []
+
+        rows_list: List[Any] = list(rows)
+        columns_list: List[str] = [str(column) for column in columns]
+
+        if not rows_list:
+            return {"summary": "No rows returned."}
+
+        first_row = rows_list[0]
+        if isinstance(first_row, Mapping):
+            if not columns_list:
+                columns_list = [str(key) for key in first_row.keys()]
+            sample_columns = columns_list[:5]
+            sample_details = ", ".join(
+                f"{column}={first_row.get(column)!r}" for column in sample_columns
+            )
+        else:
+            sample_columns = ["value"]
+            columns_list = columns_list or sample_columns
+            sample_details = repr(first_row)
+
+        row_count = len(rows_list)
+        column_count = len(columns_list)
+
+        parts = [
+            f"{row_count} row{'s' if row_count != 1 else ''} returned",
+            f"{column_count} column{'s' if column_count != 1 else ''} ({', '.join(columns_list[:5])})",
+            f"Sample: {sample_details}",
+        ]
+        return {"summary": ". ".join(parts)}
+
+
+def _normalize_tabular_result(result: Any) -> Tuple[List[Dict[str, Any]], List[str]]:
+    if pd is not None and isinstance(result, pd.DataFrame):
+        columns = [str(column) for column in result.columns]
+        rows = [
+            {str(key): value for key, value in row.items()}
+            for row in result.to_dict(orient="records")
+        ]
+        return rows, columns
+
+    if isinstance(result, Sequence) and not isinstance(result, (str, bytes, bytearray)):
+        rows_sequence: Sequence[Any] = result
+        if not rows_sequence:
+            return [], []
+        first_item = rows_sequence[0]
+        if isinstance(first_item, Mapping):
+            columns = sorted({str(key) for row in rows_sequence for key in row.keys()})
+            normalized_rows = [
+                {column: row.get(column) for column in columns}
+                for row in rows_sequence
+            ]
+            return normalized_rows, columns
+        columns = ["value"]
+        normalized_rows = [{"value": item} for item in rows_sequence]
+        return normalized_rows, columns
+
+    return ([{"value": result}], ["value"])
+
+
+def register_default_tools(
+    *,
+    config_service: ConfigService,
+    registry: ToolRegistry,
+    sql_tool: Optional[SQLExecutionTool] = None,
+) -> None:
+    """Register built-in tools for schema inspection, SQL execution and summarisation."""
+
+    runtime_sql_tool = sql_tool or create_sqlalchemy_tool()
+    registry.register("sql", runtime_sql_tool)
+
+    registry.register_definition(
+        ToolDefinition(
+            name="schema_inspection",
+            description="Inspect the connected database schema using the configured SQL connector.",
+            input_schema={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "properties": {"schema": {"type": "string"}},
+                "required": ["schema"],
+            },
+            handler=_SchemaInspectionHandler(config_service, runtime_sql_tool),
+        )
+    )
+
+    registry.register_definition(
+        ToolDefinition(
+            name="run_sql",
+            description="Execute a SQL statement against the configured database and return the rows.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "sql": {"type": "string", "description": "SQL statement to execute."}
+                },
+                "required": ["sql"],
+                "additionalProperties": False,
+            },
+            output_schema={
+                "type": "object",
+                "properties": {
+                    "rows": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                    },
+                    "columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+                "required": ["rows", "columns"],
+            },
+            handler=_RunSQLHandler(config_service, runtime_sql_tool),
+        )
+    )
+
+    registry.register_definition(
+        ToolDefinition(
+            name="summarize_results",
+            description="Provide a lightweight natural language summary for tabular query results.",
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "rows": {
+                        "type": "array",
+                        "items": {"type": "object"},
+                        "description": "Tabular rows to be summarised.",
+                    },
+                    "columns": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional ordered list of column names.",
+                    },
+                },
+                "required": ["rows"],
+            },
+            output_schema={
+                "type": "object",
+                "properties": {"summary": {"type": "string"}},
+                "required": ["summary"],
+            },
+            handler=_SummarizeResultsHandler(),
+        )
+    )
+
+
+__all__ = ["register_default_tools"]

--- a/config/mcp.json
+++ b/config/mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "db-agent": {
+      "command": "python",
+      "args": ["-m", "mcp_server.main"],
+      "transport": {
+        "type": "stdio"
+      },
+      "env": {
+        "DB_DRIVER": "postgres",
+        "DB_HOST": "localhost",
+        "DB_PORT": "5432",
+        "DB_NAME": "database",
+        "DB_USER": "user",
+        "DB_PASSWORD": "password"
+      }
+    }
+  }
+}

--- a/db-agent.py
+++ b/db-agent.py
@@ -10,7 +10,7 @@ from agent_runtime import (
     ConfigService,
     OrchestratorEventType,
     ToolRegistry,
-    create_sqlalchemy_tool,
+    register_default_tools,
 )
 from helpers.config_store import load_from_env, save_to_env
 from helpers.css_settings import custom_css
@@ -52,7 +52,10 @@ else:
 
 if "tool_registry" not in st.session_state:
     registry = ToolRegistry()
-    registry.register("sql", create_sqlalchemy_tool())
+    register_default_tools(
+        config_service=st.session_state["config_service"],
+        registry=registry,
+    )
     st.session_state["tool_registry"] = registry
 
 if "runtime_client" not in st.session_state:

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,38 @@
+# Model Context Protocol Server
+
+This repository ships with a stdio-based [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes the agent runtime tools. The server is implemented in `mcp_server/main.py` and can be used by MCP-compatible clients (such as the VS Code MCP extension) to access schema inspection, SQL execution, and result summarisation functionality.
+
+## Running the server
+
+```bash
+python -m mcp_server.main
+```
+
+The server reads database and model configuration from environment variables using the existing runtime configuration service. You can export the variables before starting the server or load them via `.env` using `python-dotenv`.
+
+Key variables include:
+
+- `DB_DRIVER`, `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`
+- `LLM_BACKEND`, `MODEL`, `LLM_ENDPOINT`, `LLM_API_KEY`
+
+## Exposed tools
+
+The MCP server surfaces three tools that mirror the built-in runtime capabilities:
+
+| Tool | Description |
+| ---- | ----------- |
+| `schema_inspection` | Returns the database schema for the configured connector. |
+| `run_sql` | Executes an arbitrary SQL statement and returns the rows/columns. |
+| `summarize_results` | Provides a short natural language summary for a tabular result set. |
+
+Each tool advertises JSON schemas for its arguments and results. See the integration tests in `tests/test_mcp_server.py` for end-to-end request/response examples.
+
+## VS Code configuration example
+
+The MCP VS Code extension looks for a `mcp.json` file. A ready-to-copy example lives at [`config/mcp.json`](../config/mcp.json) and defines a `db-agent` server entry that launches this project via `python -m mcp_server.main`.
+
+To use it:
+
+1. Copy `config/mcp.json` to your VS Code user settings directory (or merge it into an existing MCP configuration).
+2. Adjust the `env` block to point to your database credentials and model provider keys.
+3. Reload VS Code and connect to the `db-agent` server from the MCP extension UI.

--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -1,0 +1,1 @@
+"""Model Context Protocol server for db-agent."""

--- a/mcp_server/main.py
+++ b/mcp_server/main.py
@@ -1,0 +1,180 @@
+"""Stdio MCP server exposing db-agent runtime tools."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from typing import IO, Any, Dict, Optional
+
+from agent_runtime import ConfigService, ToolRegistry, register_default_tools
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MCPServer:
+    """Minimal JSON-RPC 2.0 server that follows the MCP stdio transport."""
+
+    def __init__(
+        self,
+        input_stream: IO[bytes],
+        output_stream: IO[bytes],
+        *,
+        tool_registry: ToolRegistry,
+    ) -> None:
+        self._input = input_stream
+        self._output = output_stream
+        self._tool_registry = tool_registry
+        self._initialized = False
+
+    def serve(self) -> None:
+        """Process JSON-RPC requests until the input stream is exhausted."""
+
+        while True:
+            try:
+                payload = self._read_message()
+            except Exception as exc:  # pragma: no cover - defensive error path
+                LOGGER.exception("Failed to read MCP request")
+                self._write_message(self._error_response(None, -32700, f"Parse error: {exc}"))
+                break
+
+            if payload is None:
+                break
+
+            try:
+                response = asyncio.run(self._handle_request(payload))
+            except Exception as exc:  # pragma: no cover - defensive error path
+                LOGGER.exception("Unhandled error while processing MCP request")
+                response = self._error_response(payload.get("id"), -32603, str(exc))
+
+            if response is not None:
+                self._write_message(response)
+
+    async def _handle_request(self, payload: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        if not isinstance(payload, dict):
+            return self._error_response(None, -32600, "Invalid request.")
+
+        request_id = payload.get("id")
+        method = payload.get("method")
+        params = payload.get("params") or {}
+        jsonrpc = payload.get("jsonrpc")
+
+        if jsonrpc != "2.0":
+            return self._error_response(request_id, -32600, "Invalid JSON-RPC version.")
+
+        if method == "initialize":
+            self._initialized = True
+            result = {
+                "protocolVersion": "0.1",
+                "serverInfo": {"name": "db-agent", "version": "0.1.0"},
+                "capabilities": {
+                    "tools": {"list": True, "call": True},
+                },
+            }
+            return self._success_response(request_id, result)
+
+        if method in {"shutdown", "exit"}:
+            # Shutdown is best-effort; respond once and terminate.
+            self._initialized = False
+            return self._success_response(request_id, None)
+
+        if request_id is None:
+            # Notifications are acknowledged silently.
+            return None
+
+        if not self._initialized:
+            return self._error_response(request_id, -32002, "Server is not initialized.")
+
+        if method in {"tools/list", "list_tools"}:
+            tools = [definition.to_protocol_dict() for definition in self._tool_registry.definitions()]
+            return self._success_response(request_id, {"tools": tools})
+
+        if method in {"tools/call", "call_tool"}:
+            name = params.get("name")
+            if not isinstance(name, str) or not name:
+                return self._error_response(request_id, -32602, "Tool name must be provided.")
+            try:
+                definition = self._tool_registry.get_definition(name)
+            except KeyError as exc:
+                return self._error_response(request_id, -32601, str(exc))
+
+            arguments = params.get("arguments") or {}
+            if not isinstance(arguments, dict):
+                return self._error_response(request_id, -32602, "Tool arguments must be an object.")
+
+            try:
+                result = await definition.invoke(arguments)
+            except Exception as exc:
+                LOGGER.exception("Tool '%s' raised an exception", name)
+                return self._error_response(request_id, -32603, f"Tool '{name}' failed: {exc}")
+
+            return self._success_response(request_id, {"content": result})
+
+        return self._error_response(request_id, -32601, f"Unknown method: {method}")
+
+    def _read_message(self) -> Optional[Dict[str, Any]]:
+        header_lines = []
+        while True:
+            line = self._input.readline()
+            if not line:
+                return None
+            if line == b"\r\n":
+                break
+            header_lines.append(line.decode("utf-8").rstrip("\r\n"))
+
+        headers: Dict[str, str] = {}
+        for header_line in header_lines:
+            if ":" not in header_line:
+                continue
+            key, value = header_line.split(":", 1)
+            headers[key.strip().lower()] = value.strip()
+
+        content_length_raw = headers.get("content-length")
+        if not content_length_raw:
+            raise ValueError("Missing Content-Length header.")
+        try:
+            content_length = int(content_length_raw)
+        except ValueError as exc:
+            raise ValueError("Invalid Content-Length header.") from exc
+
+        body = self._input.read(content_length)
+        if len(body) < content_length:
+            raise ValueError("Incomplete message body.")
+
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ValueError("Invalid JSON payload.") from exc
+
+    def _write_message(self, message: Dict[str, Any]) -> None:
+        payload = json.dumps(message).encode("utf-8")
+        header = f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii")
+        self._output.write(header)
+        self._output.write(payload)
+        self._output.flush()
+
+    @staticmethod
+    def _success_response(request_id: Any, result: Any) -> Dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    @staticmethod
+    def _error_response(request_id: Any, code: int, message: str) -> Dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}}
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    config_service = ConfigService()
+    registry = ToolRegistry()
+    register_default_tools(config_service=config_service, registry=registry)
+
+    server = MCPServer(
+        sys.stdin.buffer,
+        sys.stdout.buffer,
+        tool_registry=registry,
+    )
+    server.serve()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import io
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agent_runtime import ConfigService, ToolRegistry, register_default_tools
+from mcp_server.main import MCPServer
+
+
+class _FakeSQLTool:
+    def get_schema(self, config):
+        return "table users (id int)"
+
+    def run_query(self, config, query):
+        return [
+            {"id": 1, "name": "Ada"},
+            {"id": 2, "name": "Linus"},
+        ]
+
+
+def _encode_message(payload: dict) -> bytes:
+    body = json.dumps(payload).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    return header + body
+
+
+def _read_messages(stream: io.BytesIO) -> list[dict]:
+    messages: list[dict] = []
+    while True:
+        header_line = stream.readline()
+        if not header_line:
+            break
+        headers: dict[str, str] = {}
+        while header_line not in (b"", b"\r\n"):
+            key, value = header_line.decode("utf-8").split(":", 1)
+            headers[key.strip().lower()] = value.strip()
+            header_line = stream.readline()
+        length = int(headers["content-length"])
+        body = stream.read(length)
+        messages.append(json.loads(body.decode("utf-8")))
+    return messages
+
+
+def test_mcp_server_round_trip() -> None:
+    config_service = ConfigService({"DB_DRIVER": "postgres"})
+    registry = ToolRegistry()
+    register_default_tools(
+        config_service=config_service,
+        registry=registry,
+        sql_tool=_FakeSQLTool(),
+    )
+
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {"clientInfo": {"name": "test", "version": "0"}},
+    }
+    list_tools = {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}
+    call_schema = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": "schema_inspection", "arguments": {}},
+    }
+    call_query = {
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {"name": "run_sql", "arguments": {"sql": "select * from users"}},
+    }
+
+    input_stream = io.BytesIO(
+        _encode_message(initialize)
+        + _encode_message(list_tools)
+        + _encode_message(call_schema)
+        + _encode_message(call_query)
+    )
+    output_stream = io.BytesIO()
+
+    server = MCPServer(
+        input_stream,
+        output_stream,
+        tool_registry=registry,
+    )
+    server.serve()
+
+    output_stream.seek(0)
+    responses = _read_messages(output_stream)
+    assert len(responses) == 4
+
+    assert responses[0]["result"]["protocolVersion"] == "0.1"
+    assert len(responses[1]["result"]["tools"]) >= 3
+
+    schema_payload = responses[2]["result"]["content"]
+    assert schema_payload == {"schema": "table users (id int)"}
+
+    query_payload = responses[3]["result"]["content"]
+    assert query_payload["columns"] == ["id", "name"]
+    assert query_payload["rows"][1]["name"] == "Linus"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from agent_runtime import ConfigService, ToolRegistry, register_default_tools
+
+
+class _FakeSQLTool:
+    def __init__(self) -> None:
+        self.last_query: str | None = None
+
+    def get_schema(self, config):  # pragma: no cover - config used indirectly
+        assert config["DB_DRIVER"] == "postgres"
+        return "table users (id int)"
+
+    def run_query(self, config, query):
+        self.last_query = query
+        return [
+            {"id": 1, "name": "Ada"},
+            {"id": 2, "name": "Linus"},
+        ]
+
+
+@pytest.fixture
+def registry_with_tools() -> ToolRegistry:
+    config_service = ConfigService({"DB_DRIVER": "postgres"})
+    registry = ToolRegistry()
+    register_default_tools(
+        config_service=config_service,
+        registry=registry,
+        sql_tool=_FakeSQLTool(),
+    )
+    return registry
+
+
+def test_tool_definitions_registered(registry_with_tools: ToolRegistry) -> None:
+    definitions = {definition.name: definition for definition in registry_with_tools.definitions()}
+    assert {"schema_inspection", "run_sql", "summarize_results"} <= definitions.keys()
+
+    schema_result = asyncio.run(definitions["schema_inspection"].invoke({}))
+    assert schema_result == {"schema": "table users (id int)"}
+
+    query_result = asyncio.run(definitions["run_sql"].invoke({"sql": "select * from users"}))
+    assert registry_with_tools.get("sql").last_query == "select * from users"  # type: ignore[attr-defined]
+    assert query_result["columns"] == ["id", "name"]
+    assert query_result["rows"][0]["id"] == 1
+
+    summary = asyncio.run(
+        definitions["summarize_results"].invoke(
+            {
+                "rows": query_result["rows"],
+                "columns": query_result["columns"],
+            }
+        )
+    )
+    assert "2 rows" in summary["summary"]
+    assert "id" in summary["summary"]


### PR DESCRIPTION
## Summary
- add structured tool definitions for schema inspection, SQL execution, and summarisation
- implement a stdio MCP server exposing the runtime tools with documentation and sample VS Code config
- add integration tests that exercise the new tool definitions and MCP round trip

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68f584f49f588333812327d86314d7f1