### PR TITLE
Fix Terraform security findings, dismiss stale Code Scanning alerts

### DIFF
--- a/legacy/streamlit-app/infra/terraform/aws/main.tf
+++ b/legacy/streamlit-app/infra/terraform/aws/main.tf
@@ -70,6 +70,17 @@ resource "aws_security_group" "rds" {
     }
   }
 
+  # RDS has no need to initiate connections outside the VPC — without an
+  # explicit egress rule, AWS applies an implicit "allow all outbound"
+  # default on the security group, which is what this closes.
+  egress {
+    description = "Restrict egress to within the VPC only"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [data.aws_vpc.default.cidr_block]
+  }
+
   tags = merge(local.common_tags, { Name = "${var.project_name}-rds" })
 }
 
@@ -89,12 +100,49 @@ resource "aws_kms_alias" "s3" {
 }
 
 # ── S3 Bucket — access logs ───────────────────────────────────────────────────
-
+# This bucket is the logging *destination* for the data bucket below — it's
+# the terminal case and intentionally doesn't log to itself.
+#trivy:ignore:AWS-0089
 resource "aws_s3_bucket" "logs" {
   bucket        = "${var.s3_bucket_name}-logs"
   force_destroy = true
 
   tags = merge(local.common_tags, { Name = "${var.s3_bucket_name}-logs", Purpose = "access-logs" })
+}
+
+resource "aws_s3_bucket_versioning" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# SSE-KMS isn't supported for S3 server access logging destination buckets
+# (AWS-0132's own check description says so) — SSE-S3 below is the correct
+# choice for this bucket specifically, not the KMS CMK used on the data bucket.
+#trivy:ignore:AWS-0132
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# ── KMS key — RDS ──────────────────────────────────────────────────────────────
+
+resource "aws_kms_key" "rds" {
+  description             = "RDS storage + Performance Insights encryption key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = merge(local.common_tags, { Name = "${var.project_name}-rds-key" })
+}
+
+resource "aws_kms_alias" "rds" {
+  name          = "alias/${var.project_name}-rds"
+  target_key_id = aws_kms_key.rds.key_id
 }
 
 resource "aws_s3_bucket_public_access_block" "logs" {
@@ -168,12 +216,14 @@ resource "aws_db_instance" "this" {
   publicly_accessible = var.publicly_accessible
 
   storage_encrypted                   = true
+  kms_key_id                          = aws_kms_key.rds.arn
   iam_database_authentication_enabled = true
   deletion_protection                 = true
   skip_final_snapshot                 = true
 
-  backup_retention_period = 30
-  performance_insights_enabled = true
+  backup_retention_period         = 30
+  performance_insights_enabled    = true
+  performance_insights_kms_key_id = aws_kms_key.rds.arn
 
   tags = merge(local.common_tags, { Name = "${var.project_name}-postgres" })
 }


### PR DESCRIPTION
## Summary

~12 Terraform/IaC alerts were open in the Security tab. Investigated each rather than assuming:

- **9 were stale** — already fixed by commit 7be6523 ("Fix security and quality warnings from GitHub code scanning"), which added KMS encryption, RDS deletion protection/IAM auth, S3 bucket logging, and EKS control-plane logging. The alerts predate that fix and were never re-scanned since (the workflow that produces them is `workflow_dispatch`-only). Dismissed via the Code Scanning API with a comment pointing at the fix commit.
- **2 were a deliberate accepted-risk design** (EKS public access, variable-driven, already documented inline via `#trivy:ignore`). Dismissed as "won't fix" with that justification.
- **3 were genuinely still open**, found by running the actual scanner locally rather than trusting the stale list:
  - RDS security group had no explicit egress rule (implicit AWS "allow all outbound" applied) — added a VPC-restricted egress rule.
  - S3 access-logs bucket had no versioning/encryption — added both, using SSE-S3 not KMS (the KMS check's own description says SSE-KMS isn't supported for logging destination buckets) and suppressing the "bucket should log somewhere" check on the logs bucket itself (it *is* the destination).
  - RDS Performance Insights used the AWS-managed key instead of a CMK — added a dedicated KMS key for RDS.

## Why not just re-run the CI workflow

The workflow that produces these findings (`legacy-db-agent-ci-pipeline.yml`) also builds/pushes a Docker image publicly and, by default, applies real Terraform changes to AWS/DigitalOcean. Installed `trivy` locally and ran the identical `scan-type: config` check the workflow uses, against the actual current code, with zero side effects.

## Verification

```
$ terraform validate   # aws/main.tf — Success
$ trivy config legacy/streamlit-app/infra/terraform --severity CRITICAL,HIGH,MEDIUM,LOW
aws              terraform   0
aws-eks          terraform   0
aws-eks/main.tf  terraform   0
aws/main.tf      terraform   0
digitalocean     terraform   0
```

Zero misconfigurations across every Terraform stack in the repo, confirmed with the same scanner the CI pipeline uses.

## Note on container CVE alerts

The ~200 remaining Security tab alerts (glibc, util-linux, perl, systemd, etc.) are Trivy scanning the Docker base image (`python:3.11-slim`), not this repo's code. Left untouched — bulk-dismissing ~200 alerts isn't something to do without separate, explicit sign-off, and the real fix (slimmer/distroless base image) is a bigger change than this PR's scope.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>