### PR TITLE
Add optional per-deployment knowledge file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,11 @@ nodejs-app/data/memory_store.jsonl
 # keep the data/ placeholder committed
 !**/data/.gitkeep
 
+# Per-deployment knowledge file is personal/local config, not shared code —
+# same pattern as .env vs .env.example.
+nodejs-app/knowledge.json
+!nodejs-app/knowledge.json.example
+
 # ── Python build & packaging ──────────────────────────────────────────────────
 dist/
 build/

--- a/nodejs-app/README.md
+++ b/nodejs-app/README.md
@@ -70,6 +70,23 @@ documented-supported) — the deployment shape is the same generic
   SQL repair-on-failure loop (failed execution → error fed back to the LLM →
   re-validated before retrying) — same behavior, ported by hand since this is
   a separate runtime, not a shared library.
+- **Optional knowledge file** (`knowledge.js`, `knowledge.json`): the schema
+  alone (table/column names + types) doesn't carry business terminology,
+  ambiguous-column meaning, or house rules — this is where those go. Copy
+  `knowledge.json.example` to `knowledge.json` (gitignored, per-deployment,
+  same pattern as `.env`) to add:
+  - **descriptions** — column/table notes and synonyms
+  - **expressions** — reusable metric definitions (e.g. `revenue = SUM(quantity * price)`)
+  - **examples** — question → correct SQL pairs (few-shot; small local models
+    benefit disproportionately from these)
+  - **instructions** — free-text rules applied to every query
+
+  Read fresh on every request, not cached at startup, so edits take effect
+  immediately — this is meant to be iterated on, not configured once.
+  Missing file = zero change to current behavior. Verified: the same
+  ambiguous question ("What is the revenue by category?") includes cancelled
+  orders without a knowledge file and correctly excludes them with one, purely
+  from the injected instruction.
 - **Cross-platform contextual memory** (`memory.js`, ported from
   `../core/memory.py`): after each answered question, a second LLM call
   produces a redacted summary (never raw SQL/rows, and — per a code review

--- a/nodejs-app/knowledge.js
+++ b/nodejs-app/knowledge.js
@@ -1,0 +1,93 @@
+// knowledge.js — optional per-deployment context injected into the prompt
+// alongside the raw schema. Fixes the class of errors that come from the
+// LLM not knowing business terminology, ambiguous columns, or house rules —
+// the schema alone (table/column names + types) doesn't carry any of that.
+//
+// Strictly optional: missing/absent knowledge.json means zero change to
+// existing behavior. Read fresh on every request (like getSchema()) rather
+// than cached at startup, so editing the file takes effect immediately —
+// this is meant to be iterated on while curating, not configured once.
+//
+// Expected shape (all fields optional):
+// {
+//   "descriptions": {
+//     "orders.ordered_at": "date the order was placed; synonyms: purchase date, order date"
+//   },
+//   "expressions": {
+//     "revenue": "SUM(quantity * price)"
+//   },
+//   "examples": [
+//     { "question": "Who are our best customers?", "sql": "SELECT ..." }
+//   ],
+//   "instructions": [
+//     "Exclude cancelled orders unless the question explicitly asks for them."
+//   ]
+// }
+
+import fs from "node:fs";
+
+export function loadKnowledge(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (exc) {
+    console.warn(`[knowledge] could not read ${filePath}: ${exc.message || exc}`);
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(raw);
+    return {
+      descriptions: data.descriptions && typeof data.descriptions === "object" ? data.descriptions : {},
+      expressions: data.expressions && typeof data.expressions === "object" ? data.expressions : {},
+      examples: Array.isArray(data.examples) ? data.examples : [],
+      instructions: Array.isArray(data.instructions) ? data.instructions : [],
+    };
+  } catch (exc) {
+    console.warn(`[knowledge] ${filePath} is not valid JSON, ignoring: ${exc.message || exc}`);
+    return null;
+  }
+}
+
+export function formatKnowledge(knowledge) {
+  if (!knowledge) return "";
+
+  const sections = [];
+
+  const descEntries = Object.entries(knowledge.descriptions);
+  if (descEntries.length > 0) {
+    sections.push(
+      "Column/table notes:\n" +
+        descEntries.map(([key, desc]) => `  ${key}: ${desc}`).join("\n")
+    );
+  }
+
+  const exprEntries = Object.entries(knowledge.expressions);
+  if (exprEntries.length > 0) {
+    sections.push(
+      "Reusable expressions (use these exact definitions when the question refers to them):\n" +
+        exprEntries.map(([name, expr]) => `  ${name} = ${expr}`).join("\n")
+    );
+  }
+
+  if (knowledge.examples.length > 0) {
+    sections.push(
+      "Example questions and their correct SQL for this schema:\n" +
+        knowledge.examples
+          .map((ex) => `  Q: ${ex.question}\n  SQL: ${ex.sql}`)
+          .join("\n\n")
+    );
+  }
+
+  if (knowledge.instructions.length > 0) {
+    sections.push(
+      "General instructions (apply to every query):\n" +
+        knowledge.instructions.map((rule) => `  - ${rule}`).join("\n")
+    );
+  }
+
+  if (sections.length === 0) return "";
+  return "\n\n" + sections.join("\n\n");
+}

--- a/nodejs-app/knowledge.json.example
+++ b/nodejs-app/knowledge.json.example
@@ -1,0 +1,18 @@
+{
+  "descriptions": {
+    "orders.status": "one of 'completed', 'pending', 'cancelled' (lowercase, exact match)",
+    "orders.ordered_at": "date the order was placed; synonyms: purchase date, order date"
+  },
+  "expressions": {
+    "revenue": "SUM(quantity * price)"
+  },
+  "examples": [
+    {
+      "question": "Who are our best customers?",
+      "sql": "SELECT c.name, SUM(o.quantity * p.price) AS total_spent FROM orders o JOIN customers c ON o.customer_id = c.id JOIN products p ON o.product_id = p.id GROUP BY c.id ORDER BY total_spent DESC LIMIT 5"
+    }
+  ],
+  "instructions": [
+    "Exclude cancelled orders unless the question explicitly asks for them."
+  ]
+}

--- a/nodejs-app/server.js
+++ b/nodejs-app/server.js
@@ -13,6 +13,7 @@ import OpenAI from "openai";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { LocalJsonBackend, S3VectorsBackend, fetchRelevantMemories, writeMemory } from "./memory.js";
+import { formatKnowledge, loadKnowledge } from "./knowledge.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -29,6 +30,10 @@ const LLM_BASE_URL = process.env.LLM_BASE_URL || "https://api.openai.com/v1";
 const LLM_API_KEY = process.env.LLM_API_KEY || "no-key";
 const LLM_MODEL = process.env.LLM_MODEL || "gpt-4o-mini";
 const MAX_REPAIR_ATTEMPTS = 2;
+// Optional per-deployment context (descriptions, expressions, example
+// queries, instructions) — see knowledge.js. Absent file = no change to
+// existing behavior.
+const KNOWLEDGE_PATH = process.env.KNOWLEDGE_FILE || path.join(__dirname, "knowledge.json");
 
 // The chat model (SQL generation, repair, memory summarization) and the
 // embedding model don't need to be the same endpoint. This matters for
@@ -115,18 +120,20 @@ Always respond with valid JSON in this exact format:
 
 Do not include any text outside the JSON object.`;
 
-function buildUserPrompt(question, schema) {
+function buildUserPrompt(question, schema, knowledge) {
   return `Database schema:
 ${formatSchema(schema)}
+${formatKnowledge(knowledge)}
 
 User question: ${question}
 
 Return only the JSON object described above.`;
 }
 
-function buildRepairPrompt(question, schema, failedSql, error) {
+function buildRepairPrompt(question, schema, failedSql, error, knowledge) {
   return `Database schema:
 ${formatSchema(schema)}
+${formatKnowledge(knowledge)}
 
 User question: ${question}
 
@@ -212,6 +219,7 @@ function runQuery(sql) {
 
 async function runPipeline(question) {
   const schema = getSchema();
+  const knowledge = loadKnowledge(KNOWLEDGE_PATH);
   const output = {
     question,
     schemaContext: formatSchema(schema),
@@ -225,7 +233,7 @@ async function runPipeline(question) {
   };
 
   try {
-    const raw = await callLlm(SYSTEM_PROMPT, buildUserPrompt(question, schema));
+    const raw = await callLlm(SYSTEM_PROMPT, buildUserPrompt(question, schema, knowledge));
     const parsed = parseSqlResponse(raw);
     output.sql = parsed.sql;
     output.explanation = parsed.explanation;
@@ -258,7 +266,7 @@ async function runPipeline(question) {
 
         const repairRaw = await callLlm(
           SYSTEM_PROMPT,
-          buildRepairPrompt(question, schema, currentSql, String(dbErr.message || dbErr))
+          buildRepairPrompt(question, schema, currentSql, String(dbErr.message || dbErr), knowledge)
         );
         const repaired = parseSqlResponse(repairRaw);
         const repairValidation = validateSql(repaired.sql);
@@ -310,6 +318,7 @@ app.get("/api/config", (req, res) => {
     memoryBackend: process.env.MEMORY_BACKEND || "local",
     embeddingBaseUrl: EMBEDDING_BASE_URL,
     embeddingModel: MEMORY.embeddingModel,
+    knowledgeLoaded: loadKnowledge(KNOWLEDGE_PATH) !== null,
   });
 });
 


### PR DESCRIPTION
Closes #37.

## Summary

Adds `nodejs-app/knowledge.js` + optional `knowledge.json`, injected into the prompt alongside the schema:

- **descriptions** — column/table notes and synonyms
- **expressions** — reusable metric definitions (e.g. `revenue = SUM(quantity * price)`)
- **examples** — question → correct SQL pairs (few-shot)
- **instructions** — free-text rules applied to every query

Strictly optional: missing file = zero change to current behavior (`knowledgeLoaded: false` in `/api/config`). Read fresh on every request rather than cached at startup, so edits take effect immediately without a restart.

`knowledge.json` is gitignored (per-deployment/personal, same pattern as `.env` vs `.env.example`); `knowledge.json.example` ships as a template using the actual demo schema.

## Verification

Ran the identical ambiguous question through the real pipeline against local Ollama, with and without the knowledge file:

- Without: `SELECT p.category, SUM(o.quantity * p.price) AS revenue FROM orders o JOIN products p ... GROUP BY p.category` — includes cancelled orders
- With: same question, now includes `WHERE o.status = 'completed'` — purely from the injected "exclude cancelled orders" instruction, no code change between runs

Also confirmed: `node --check` clean, `npm run build` succeeds, SQL repair loop still works with knowledge loaded (no crash, `repairAttempts: 0` on a successful first try).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>