### PR TITLE
Select relevant knowledge-file entries instead of injecting the whole file

### DIFF
--- a/nodejs-app/knowledge.js
+++ b/nodejs-app/knowledge.js
@@ -90,16 +90,15 @@ async function selectRelevantExamples(examples, question, embeddingClient, embed
   try {
     const questionVector = await embed(embeddingClient, question, embeddingModel);
 
-    const scored = await Promise.all(
-      examples.map(async (ex) => {
-        let vector = exampleEmbeddingCache.get(ex.question);
-        if (!vector) {
-          vector = await embed(embeddingClient, ex.question, embeddingModel);
-          exampleEmbeddingCache.set(ex.question, vector);
-        }
-        return { ex, score: cosineSimilarity(questionVector, vector) };
-      })
-    );
+    const scored = [];
+    for (const ex of examples) {
+      let vector = exampleEmbeddingCache.get(ex.question);
+      if (!vector) {
+        vector = await embed(embeddingClient, ex.question, embeddingModel);
+        exampleEmbeddingCache.set(ex.question, vector);
+      }
+      scored.push({ ex, score: cosineSimilarity(questionVector, vector) });
+    }
 
     scored.sort((a, b) => b.score - a.score);
     return scored.slice(0, maxExamples).map((s) => s.ex);

--- a/nodejs-app/knowledge.js
+++ b/nodejs-app/knowledge.js
@@ -25,6 +25,19 @@
 // }
 
 import fs from "node:fs";
+import { cosineSimilarity, embed } from "./memory.js";
+
+const DEFAULT_MAX_EXAMPLES = 3;
+// Rough estimate (chars/4), not a real tokenizer — good enough to flag
+// "this knowledge file is getting large" without adding a tokenizer
+// dependency for what's currently a diagnostic warning, not a hard limit.
+const TOKEN_WARN_THRESHOLD = 800;
+
+// Keyed by exact example question text — a knowledge file is small and
+// hand-edited, so this doesn't need file-mtime invalidation: editing an
+// example's question text produces a new cache key naturally, and stale
+// entries for removed examples just sit unused (fine at this scale).
+const exampleEmbeddingCache = new Map();
 
 export function loadKnowledge(filePath) {
   if (!fs.existsSync(filePath)) return null;
@@ -49,6 +62,80 @@ export function loadKnowledge(filePath) {
     console.warn(`[knowledge] ${filePath} is not valid JSON, ignoring: ${exc.message || exc}`);
     return null;
   }
+}
+
+function mentionsWord(text, word) {
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "i").test(text);
+}
+
+// Descriptions/expressions are cheap to filter with substring/keyword
+// matching — no embeddings needed. A description for "customers.email"
+// only earns its place in the prompt if the question actually mentions
+// "customers" (or "email"); same idea for expression names like "revenue".
+function filterByKeywordMatch(entries, question) {
+  return Object.fromEntries(
+    Object.entries(entries).filter(([key]) => {
+      const table = key.split(".")[0];
+      return mentionsWord(question, table) || mentionsWord(question, key);
+    })
+  );
+}
+
+async function selectRelevantExamples(examples, question, embeddingClient, embeddingModel, maxExamples) {
+  if (examples.length <= maxExamples) return examples;
+
+  // Only worth the embedding calls once there are more examples than the
+  // cap — small files (the common case) skip this entirely.
+  try {
+    const questionVector = await embed(embeddingClient, question, embeddingModel);
+
+    const scored = await Promise.all(
+      examples.map(async (ex) => {
+        let vector = exampleEmbeddingCache.get(ex.question);
+        if (!vector) {
+          vector = await embed(embeddingClient, ex.question, embeddingModel);
+          exampleEmbeddingCache.set(ex.question, vector);
+        }
+        return { ex, score: cosineSimilarity(questionVector, vector) };
+      })
+    );
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, maxExamples).map((s) => s.ex);
+  } catch (exc) {
+    // Selection is a refinement, not a correctness requirement — if
+    // embedding fails for any reason, fall back to the first N examples
+    // rather than failing the whole request.
+    console.warn(`[knowledge] example selection skipped, using first ${maxExamples}: ${exc.message || exc}`);
+    return examples.slice(0, maxExamples);
+  }
+}
+
+// Filters a loaded knowledge object down to what's relevant to this
+// specific question, so the prompt isn't paying (in tokens, and in the
+// small-model-bias risk of irrelevant few-shot examples) for the whole
+// file on every request regardless of relevance.
+export async function selectRelevantKnowledge(
+  knowledge,
+  question,
+  embeddingClient,
+  embeddingModel,
+  { maxExamples = DEFAULT_MAX_EXAMPLES } = {}
+) {
+  if (!knowledge) return null;
+
+  const descriptions = filterByKeywordMatch(knowledge.descriptions, question);
+  const expressions = filterByKeywordMatch(knowledge.expressions, question);
+  const examples = await selectRelevantExamples(
+    knowledge.examples,
+    question,
+    embeddingClient,
+    embeddingModel,
+    maxExamples
+  );
+
+  return { descriptions, expressions, examples, instructions: knowledge.instructions };
 }
 
 export function formatKnowledge(knowledge) {
@@ -89,5 +176,14 @@ export function formatKnowledge(knowledge) {
   }
 
   if (sections.length === 0) return "";
-  return "\n\n" + sections.join("\n\n");
+
+  const text = "\n\n" + sections.join("\n\n");
+  const estimatedTokens = Math.ceil(text.length / 4); // no tokenizer dep — rough but enough to flag growth
+  if (estimatedTokens > TOKEN_WARN_THRESHOLD) {
+    console.warn(
+      `[knowledge] injected block is ~${estimatedTokens} tokens (over the ${TOKEN_WARN_THRESHOLD} warn threshold) — ` +
+        `consider trimming knowledge.json or lowering maxExamples`
+    );
+  }
+  return text;
 }

--- a/nodejs-app/memory.js
+++ b/nodejs-app/memory.js
@@ -60,7 +60,7 @@ function parseSummaryJson(raw) {
   }
 }
 
-async function embed(llm, text, embeddingModel) {
+export async function embed(llm, text, embeddingModel) {
   // The OpenAI SDK defaults to encoding_format: "base64" for embeddings.
   // At least one OpenAI-compatible endpoint we've tested (Databricks AI
   // Gateway) mishandles that and silently returns a truncated vector
@@ -122,7 +122,7 @@ Row count returned: ${rowCount}
 // Mirrors ../core/memory.py's LocalJsonBackend — no cloud setup required,
 // so this is the default and what makes the feature demoable via run_local.sh.
 
-function cosineSimilarity(a, b) {
+export function cosineSimilarity(a, b) {
   let dot = 0, normA = 0, normB = 0;
   for (let i = 0; i < a.length; i++) {
     dot += a[i] * b[i];

--- a/nodejs-app/server.js
+++ b/nodejs-app/server.js
@@ -13,7 +13,7 @@ import OpenAI from "openai";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { LocalJsonBackend, S3VectorsBackend, fetchRelevantMemories, writeMemory } from "./memory.js";
-import { formatKnowledge, loadKnowledge } from "./knowledge.js";
+import { formatKnowledge, loadKnowledge, selectRelevantKnowledge } from "./knowledge.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -120,20 +120,20 @@ Always respond with valid JSON in this exact format:
 
 Do not include any text outside the JSON object.`;
 
-function buildUserPrompt(question, schema, knowledge) {
+function buildUserPrompt(question, schema, knowledgeText) {
   return `Database schema:
 ${formatSchema(schema)}
-${formatKnowledge(knowledge)}
+${knowledgeText}
 
 User question: ${question}
 
 Return only the JSON object described above.`;
 }
 
-function buildRepairPrompt(question, schema, failedSql, error, knowledge) {
+function buildRepairPrompt(question, schema, failedSql, error, knowledgeText) {
   return `Database schema:
 ${formatSchema(schema)}
-${formatKnowledge(knowledge)}
+${knowledgeText}
 
 User question: ${question}
 
@@ -219,7 +219,18 @@ function runQuery(sql) {
 
 async function runPipeline(question) {
   const schema = getSchema();
-  const knowledge = loadKnowledge(KNOWLEDGE_PATH);
+  const rawKnowledge = loadKnowledge(KNOWLEDGE_PATH);
+  // Select relevant entries before formatting, once per request, reused for
+  // both the initial attempt and any repair retries — descriptions/
+  // expressions filtered by keyword match, examples by embedding similarity
+  // once the file has more than a few (see knowledge.js).
+  const selectedKnowledge = await selectRelevantKnowledge(
+    rawKnowledge,
+    question,
+    embeddingClient,
+    MEMORY.embeddingModel
+  );
+  const knowledgeText = formatKnowledge(selectedKnowledge);
   const output = {
     question,
     schemaContext: formatSchema(schema),
@@ -233,7 +244,7 @@ async function runPipeline(question) {
   };
 
   try {
-    const raw = await callLlm(SYSTEM_PROMPT, buildUserPrompt(question, schema, knowledge));
+    const raw = await callLlm(SYSTEM_PROMPT, buildUserPrompt(question, schema, knowledgeText));
     const parsed = parseSqlResponse(raw);
     output.sql = parsed.sql;
     output.explanation = parsed.explanation;
@@ -266,7 +277,7 @@ async function runPipeline(question) {
 
         const repairRaw = await callLlm(
           SYSTEM_PROMPT,
-          buildRepairPrompt(question, schema, currentSql, String(dbErr.message || dbErr), knowledge)
+          buildRepairPrompt(question, schema, currentSql, String(dbErr.message || dbErr), knowledgeText)
         );
         const repaired = parseSqlResponse(repairRaw);
         const repairValidation = validateSql(repaired.sql);


### PR DESCRIPTION
Closes #42. Based on `knowledge-file-37` (#41, not yet merged) since this builds directly on it — diff here is only the incremental change.

## Summary

The knowledge file injected its entire contents into every prompt regardless of relevance. Doesn't scale, and for examples specifically it's not just token waste: irrelevant few-shot examples can bias a small model toward the wrong join pattern, not merely cost tokens.

- **descriptions/expressions** — filtered by keyword match (word-boundary regex against the question). No embeddings needed.
- **examples** — selected by embedding similarity once the file has more entries than the cap (default 3). Reuses the embedding client + `cosineSimilarity`/`embed` already built for cross-platform memory (now exported from `memory.js` instead of duplicated). Files at or under the cap skip embedding calls entirely. Example embeddings cached by exact question text across requests.
- **Graceful fallback** — if embedding fails for any reason, falls back to the first N examples rather than failing the request.
- **Token-count logging** — rough estimate (chars/4, no tokenizer dependency), warns when the formatted block crosses a threshold.

## Verification

All checked directly against the running code, not assumed:

- Keyword filtering: a question mentioning "revenue" and "orders" keeps only matching entries, drops the rest
- Similarity ranking: a 5-example test file correctly ranks the near-identical-wording example first
- Skip path: a deliberately broken embedding client proves small files (≤ cap) never call embeddings
- Fallback path: same broken client with a large file still returns results (first-N), doesn't throw
- Token warning: fires correctly on an oversized synthetic file
- End-to-end against local Ollama: same ambiguous "revenue by category" question correctly excludes cancelled orders 3/3 runs with the real example file

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>