### PR TITLE
Use LIKE instead of exact equality when matching hidden text columns

### DIFF
--- a/nodejs-app/server.js
+++ b/nodejs-app/server.js
@@ -194,6 +194,13 @@ Rules you must follow:
 - Write exactly one statement. No semicolons in the middle.
 - The database is SQLite — use SQLite date/string functions (date('now','-1 month')),
   not MySQL/Postgres equivalents.
+- Some text columns (e.g. person names) have their real values hidden from you for
+  privacy, so you cannot see exact stored strings for them. When the question
+  names a person or gives a partial/likely value for such a column, match it with
+  LIKE '%value%' (case-insensitive substring) instead of exact equality — an exact
+  '=' will silently miss rows whenever the stored value has more to it (e.g. a last
+  name) than what the question mentioned. Only use exact equality when the column's
+  schema entry lists sample values and the question's value matches one of them.
 - If the question cannot be answered from the schema, say so in the explanation
   and set sql to an empty string.
 


### PR DESCRIPTION
## Summary
- Person-name columns (e.g. `customers.name`) are intentionally excluded from schema value sampling for privacy, so the LLM never sees exact stored strings for them
- A question like "orders for the customer named Frank" was generating `WHERE c.name = 'Frank'`, silently matching zero rows because the real value is "Frank Müller"
- System prompt now instructs the model to use `LIKE '%value%'` for such columns, reserving exact equality for columns whose schema entry actually lists sample values

## Test plan
- [x] `node --check server.js`
- [x] Manual: "show me all orders for the customer named Frank" now returns real rows via `LIKE '%Frank%'` (previously 0 rows with exact `=`)
- [x] `npm run benchmark` — 7/7 passed against local Ollama, confirming the new LIKE guidance doesn't regress exact-match cases (product/category/city lookups)
- [x] Verified no AWS bucket names/ARNs/tokens present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)