### PR TITLE
Add Milvus as a pluggable cross-platform memory backend

### DIFF
--- a/app/memory.js
+++ b/app/memory.js
@@ -9,30 +9,21 @@
 // the raw SQL or rows — produced by a second, small LLM call. That's what
 // makes it safe to write into a shared, cross-boundary store.
 //
-// Two backends, both behind the same put()/query() interface:
-//   LocalJsonBackend  — JSONL + cosine similarity, no cloud setup, the
-//                       default (matches ../core/memory.py's LocalJsonBackend).
-//   S3VectorsBackend  — @aws-sdk/client-s3vectors (AWS S3 Vectors, preview).
-//                       Bucket + index are expected to already exist — this
-//                       class only puts/queries, to keep IAM scoped tight.
+// This file is backend-agnostic: summarization, embedding, and the public
+// write/fetch/invalidate API. The actual storage implementations (local
+// JSONL, AWS S3 Vectors, Milvus, ...) live in memoryBackends/ — see
+// memoryBackends/index.js for the pluggable registry. Every backend
+// implements the same put()/query()/invalidateFollowup() interface.
 
-import fs from "node:fs";
-import path from "node:path";
 import crypto from "node:crypto";
-import {
-  S3VectorsClient,
-  PutVectorsCommand,
-  QueryVectorsCommand,
-  GetVectorsCommand,
-} from "@aws-sdk/client-s3vectors";
 
-// Shared by invalidateFollowup on both backends — case/whitespace/trailing-
+// Shared by invalidateFollowup on every backend — case/whitespace/trailing-
 // punctuation-insensitive so "Show me X?" matches a stored "show me x".
 // This only catches literal repeats of a follow-up string, not semantically
 // similar rephrasings; that's the realistic case here since
 // suggestedFollowups are literal question strings surfaced verbatim in the
 // UI (see Suggestions.tsx), not paraphrased on display.
-function normalizeQuestion(text) {
+export function normalizeQuestion(text) {
   return String(text).trim().toLowerCase().replace(/[?.!]+$/, "");
 }
 
@@ -129,10 +120,8 @@ Row count returned: ${rowCount}
   };
 }
 
-// ── Local backend (JSONL + cosine similarity) ───────────────────────────────
-// Mirrors ../core/memory.py's LocalJsonBackend — no cloud setup required,
-// so this is the default and what makes the feature demoable via run_local.sh.
-
+// Generic vector math, shared by any backend that scores similarity
+// client-side (LocalJsonBackend) — see memoryBackends/.
 export function cosineSimilarity(a, b) {
   let dot = 0, normA = 0, normB = 0;
   for (let i = 0; i < a.length; i++) {
@@ -141,207 +130,6 @@ export function cosineSimilarity(a, b) {
     normB += b[i] * b[i];
   }
   return dot / ((Math.sqrt(normA) || 1) * (Math.sqrt(normB) || 1));
-}
-
-export class LocalJsonBackend {
-  constructor(filePath) {
-    this.path = filePath;
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  }
-
-  put(record, vector) {
-    const row = JSON.stringify({ record, vector }) + "\n";
-    fs.appendFileSync(this.path, row);
-  }
-
-  query(vector, { excludeAgent, topK }) {
-    if (!fs.existsSync(this.path)) return [];
-
-    const now = Date.now() / 1000;
-    const lines = fs.readFileSync(this.path, "utf-8").split("\n").filter(Boolean);
-
-    const scored = [];
-    for (const line of lines) {
-      let row;
-      try {
-        row = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (!row?.record || !row?.vector) continue;
-      if (row.record.sourceAgent === excludeAgent) continue;
-      if (row.record.ttlEpoch < now) continue;
-      scored.push([cosineSimilarity(vector, row.vector), row.record]);
-    }
-
-    scored.sort((a, b) => b[0] - a[0]);
-    return scored.slice(0, topK).map(([, record]) => record);
-  }
-
-  // Strips a specific follow-up question out of every record that suggests
-  // it, rather than deleting the whole record — the record's insightSummary
-  // may still be a valid cross-agent insight even if one of its suggested
-  // follow-ups turned out to be a bad prompt (e.g. flagged by a benchmark
-  // failure or a thumbs-down). Rewrites the file in place; JSONL has no
-  // in-place update primitive.
-  invalidateFollowup(questionText) {
-    if (!fs.existsSync(this.path)) return { removed: 0 };
-    const target = normalizeQuestion(questionText);
-    const lines = fs.readFileSync(this.path, "utf-8").split("\n").filter(Boolean);
-
-    let removed = 0;
-    const rewritten = lines.map((line) => {
-      let row;
-      try {
-        row = JSON.parse(line);
-      } catch {
-        return line;
-      }
-      const followups = row?.record?.suggestedFollowups;
-      if (!Array.isArray(followups)) return line;
-      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
-      if (filtered.length === followups.length) return line;
-      removed += followups.length - filtered.length;
-      row.record.suggestedFollowups = filtered;
-      return JSON.stringify(row);
-    });
-
-    fs.writeFileSync(this.path, rewritten.length ? rewritten.join("\n") + "\n" : "");
-    return { removed };
-  }
-}
-
-// ── S3 Vectors backend ───────────────────────────────────────────────────────
-// Mirrors ../core/memory.py's S3VectorsBackend. Over-fetches (topK * 4) and
-// filters ttlEpoch/excludeAgent client-side rather than relying on exact
-// metadata-filter operator support — S3 Vectors is a preview service and
-// filter semantics could shift; this stays correct across API changes at
-// the cost of a slightly larger response.
-
-export class S3VectorsBackend {
-  constructor({ bucket, index, region }) {
-    this.bucket = bucket;
-    this.index = index;
-    this.client = new S3VectorsClient({ region });
-  }
-
-  async put(record, vector) {
-    await this.client.send(
-      new PutVectorsCommand({
-        vectorBucketName: this.bucket,
-        indexName: this.index,
-        vectors: [
-          {
-            key: record.recordId,
-            data: { float32: vector },
-            metadata: {
-              sourceAgent: record.sourceAgent,
-              sourceDbKind: record.sourceDbKind,
-              createdAt: record.createdAt,
-              ttlEpoch: record.ttlEpoch,
-              entities: record.entities,
-              insightSummary: record.insightSummary,
-              suggestedFollowups: record.suggestedFollowups,
-            },
-          },
-        ],
-      })
-    );
-  }
-
-  async query(vector, { excludeAgent, topK }) {
-    const response = await this.client.send(
-      new QueryVectorsCommand({
-        vectorBucketName: this.bucket,
-        indexName: this.index,
-        topK: Math.max(topK * 4, 10),
-        queryVector: { float32: vector },
-        returnMetadata: true,
-        returnDistance: true,
-      })
-    );
-
-    const now = Date.now() / 1000;
-    const records = [];
-    for (const item of response.vectors || []) {
-      const meta = item.metadata || {};
-      if (meta.sourceAgent === excludeAgent) continue;
-      if (Number(meta.ttlEpoch || 0) < now) continue;
-      records.push({
-        recordId: item.key,
-        sourceAgent: meta.sourceAgent || "",
-        sourceDbKind: meta.sourceDbKind || "",
-        createdAt: meta.createdAt || "",
-        ttlEpoch: Number(meta.ttlEpoch || 0),
-        entities: meta.entities || [],
-        insightSummary: meta.insightSummary || "",
-        suggestedFollowups: meta.suggestedFollowups || [],
-      });
-      if (records.length >= topK) break;
-    }
-    return records;
-  }
-
-  // Same intent as LocalJsonBackend.invalidateFollowup, but S3 Vectors has
-  // no "list all" or text-search primitive — only vector similarity search.
-  // So this is a best-effort semantic lookup: it queries near the question's
-  // own embedding (a follow-up question is usually reasonably close to the
-  // insightSummary it was suggested alongside), then does an exact,
-  // normalized string match against the candidates' metadata before
-  // touching anything, so a low-recall miss just means "nothing found",
-  // never a wrong edit. Vector data for a match is re-fetched via
-  // GetVectorsCommand and re-written unchanged — reusing the *query*
-  // vector for the PutVectors overwrite would recenter that memory record
-  // on the invalidated question's embedding instead of its original
-  // insight, corrupting future similarity search for it.
-  async invalidateFollowup(questionText, queryVector) {
-    const target = normalizeQuestion(questionText);
-    const queryResponse = await this.client.send(
-      new QueryVectorsCommand({
-        vectorBucketName: this.bucket,
-        indexName: this.index,
-        topK: 20,
-        queryVector: { float32: queryVector },
-        returnMetadata: true,
-      })
-    );
-
-    const candidateKeys = (queryResponse.vectors || [])
-      .filter((item) => (item.metadata?.suggestedFollowups || []).some((f) => normalizeQuestion(f) === target))
-      .map((item) => item.key);
-    if (candidateKeys.length === 0) return { removed: 0 };
-
-    const getResponse = await this.client.send(
-      new GetVectorsCommand({
-        vectorBucketName: this.bucket,
-        indexName: this.index,
-        keys: candidateKeys,
-        returnData: true,
-        returnMetadata: true,
-      })
-    );
-
-    let removed = 0;
-    const updates = [];
-    for (const item of getResponse.vectors || []) {
-      const followups = item.metadata?.suggestedFollowups || [];
-      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
-      if (filtered.length === followups.length) continue;
-      removed += followups.length - filtered.length;
-      updates.push({
-        key: item.key,
-        data: item.data,
-        metadata: { ...item.metadata, suggestedFollowups: filtered },
-      });
-    }
-
-    if (updates.length > 0) {
-      await this.client.send(
-        new PutVectorsCommand({ vectorBucketName: this.bucket, indexName: this.index, vectors: updates })
-      );
-    }
-    return { removed };
-  }
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────

--- a/app/memoryBackends/index.js
+++ b/app/memoryBackends/index.js
@@ -1,0 +1,68 @@
+// memoryBackends/index.js — registry of pluggable cross-platform-memory
+// storage backends. Adding a new one (e.g. a future AIStor Memory backend,
+// once it has a public/documented API) means: write memoryBackends/foo.js
+// implementing put()/query()/invalidateFollowup(), add one entry below, and
+// nothing in server.js or memory.js needs to change.
+//
+// Every backend implements the same interface:
+//   put(record, vector) -> void | Promise<void>
+//   query(vector, { excludeAgent, topK }) -> record[] | Promise<record[]>
+//   invalidateFollowup(questionText, queryVector) -> { removed } | Promise<{ removed }>
+
+import path from "node:path";
+import { LocalJsonBackend } from "./local.js";
+import { S3VectorsBackend } from "./s3vectors.js";
+import { MilvusBackend } from "./milvus.js";
+
+const REGISTRY = {
+  local: {
+    description: "JSONL file + cosine similarity. No cloud or server setup — the default.",
+    create: (env, { dataDir }) =>
+      new LocalJsonBackend(env.MEMORY_STORE_PATH || path.join(dataDir, "memory_store.jsonl")),
+  },
+  s3vectors: {
+    description: "AWS S3 Vectors (preview). Requires a pre-provisioned vector bucket/index.",
+    create: (env) =>
+      new S3VectorsBackend({
+        bucket: env.MEMORY_S3_BUCKET || "",
+        index: env.MEMORY_ORG_ID || "demo-org",
+        region: env.MEMORY_S3_REGION || "us-east-1",
+      }),
+  },
+  milvus: {
+    description: "Milvus (self-hosted or Zilliz Cloud). Auto-creates its collection/index on first use.",
+    create: (env) =>
+      new MilvusBackend({
+        address: env.MILVUS_ADDRESS || "localhost:19530",
+        collection: env.MEMORY_ORG_ID || "demo_org",
+        // Must match EMBEDDING_MODEL's output dimension exactly — same
+        // constraint as S3 Vectors' pre-provisioned index dimension, just
+        // enforced here instead of in an out-of-band `aws s3vectors
+        // create-index` call, since Milvus collections are created by this
+        // code rather than provisioned separately.
+        dimension: Number(env.MEMORY_VECTOR_DIM || 768),
+        token: env.MILVUS_TOKEN,
+        username: env.MILVUS_USERNAME,
+        password: env.MILVUS_PASSWORD,
+        ssl: (env.MILVUS_SSL || "false").toLowerCase() === "true",
+      }),
+  },
+};
+
+export function listMemoryBackends() {
+  return Object.entries(REGISTRY).map(([name, { description }]) => ({ name, description }));
+}
+
+// `dataDir` is only used by the `local` backend's default file path — kept
+// as an explicit param (rather than each backend computing its own
+// __dirname-relative path) so every backend's storage location is
+// resolved the same way, relative to server.js's own directory.
+export function createMemoryBackend(name, { env = process.env, dataDir } = {}) {
+  const key = (name || "local").toLowerCase();
+  const entry = REGISTRY[key];
+  if (!entry) {
+    const available = Object.keys(REGISTRY).join(", ");
+    throw new Error(`Unknown MEMORY_BACKEND "${name}" — available backends: ${available}`);
+  }
+  return entry.create(env, { dataDir });
+}

--- a/app/memoryBackends/local.js
+++ b/app/memoryBackends/local.js
@@ -1,0 +1,75 @@
+// memoryBackends/local.js — JSONL + cosine similarity, no cloud/server setup.
+// Mirrors ../../core/memory.py's LocalJsonBackend — the default, and what
+// makes cross-platform memory demoable via run_local.sh with zero config.
+
+import fs from "node:fs";
+import path from "node:path";
+import { cosineSimilarity, normalizeQuestion } from "../memory.js";
+
+export class LocalJsonBackend {
+  constructor(filePath) {
+    this.path = filePath;
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  }
+
+  put(record, vector) {
+    const row = JSON.stringify({ record, vector }) + "\n";
+    fs.appendFileSync(this.path, row);
+  }
+
+  query(vector, { excludeAgent, topK }) {
+    if (!fs.existsSync(this.path)) return [];
+
+    const now = Date.now() / 1000;
+    const lines = fs.readFileSync(this.path, "utf-8").split("\n").filter(Boolean);
+
+    const scored = [];
+    for (const line of lines) {
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (!row?.record || !row?.vector) continue;
+      if (row.record.sourceAgent === excludeAgent) continue;
+      if (row.record.ttlEpoch < now) continue;
+      scored.push([cosineSimilarity(vector, row.vector), row.record]);
+    }
+
+    scored.sort((a, b) => b[0] - a[0]);
+    return scored.slice(0, topK).map(([, record]) => record);
+  }
+
+  // Strips a specific follow-up question out of every record that suggests
+  // it, rather than deleting the whole record — the record's insightSummary
+  // may still be a valid cross-agent insight even if one of its suggested
+  // follow-ups turned out to be a bad prompt (e.g. flagged by a benchmark
+  // failure or a thumbs-down). Rewrites the file in place; JSONL has no
+  // in-place update primitive.
+  invalidateFollowup(questionText) {
+    if (!fs.existsSync(this.path)) return { removed: 0 };
+    const target = normalizeQuestion(questionText);
+    const lines = fs.readFileSync(this.path, "utf-8").split("\n").filter(Boolean);
+
+    let removed = 0;
+    const rewritten = lines.map((line) => {
+      let row;
+      try {
+        row = JSON.parse(line);
+      } catch {
+        return line;
+      }
+      const followups = row?.record?.suggestedFollowups;
+      if (!Array.isArray(followups)) return line;
+      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
+      if (filtered.length === followups.length) return line;
+      removed += followups.length - filtered.length;
+      row.record.suggestedFollowups = filtered;
+      return JSON.stringify(row);
+    });
+
+    fs.writeFileSync(this.path, rewritten.length ? rewritten.join("\n") + "\n" : "");
+    return { removed };
+  }
+}

--- a/app/memoryBackends/milvus.js
+++ b/app/memoryBackends/milvus.js
@@ -1,0 +1,198 @@
+// memoryBackends/milvus.js — Milvus (self-hosted or Zilliz Cloud) via
+// @zilliz/milvus2-sdk-node.
+//
+// Unlike S3VectorsBackend, this backend auto-creates its collection/index on
+// first use rather than expecting one pre-provisioned out of band — Milvus
+// is commonly self-hosted for local/dev use (a single `docker run
+// milvusdb/milvus` gets you a real server), so removing the "go provision
+// something in a cloud console first" step matters more here than it does
+// for AWS S3 Vectors, where provisioning is deliberately manual and
+// IAM-scoped.
+//
+// Method names/shapes below were verified against the installed
+// @zilliz/milvus2-sdk-node v3 type definitions (dist/milvus/types/*.d.ts),
+// not written from memory — that package's API has shifted across majors.
+
+import { MilvusClient, DataType } from "@zilliz/milvus2-sdk-node";
+import { normalizeQuestion } from "../memory.js";
+
+const RECORD_ID_FIELD = "recordId";
+const VECTOR_FIELD = "vector";
+const METADATA_OUTPUT_FIELDS = [
+  "sourceAgent",
+  "sourceDbKind",
+  "createdAt",
+  "ttlEpoch",
+  "entities",
+  "insightSummary",
+  "suggestedFollowups",
+];
+
+export class MilvusBackend {
+  constructor({ address, collection, dimension, token, username, password, ssl }) {
+    this.collection = collection;
+    this.dimension = dimension;
+    this.client = new MilvusClient({
+      address,
+      ssl: !!ssl,
+      ...(token ? { token } : {}),
+      ...(username ? { username, password } : {}),
+    });
+    // Collection creation/loading is async and can't happen in a
+    // constructor — every public method awaits this first. Cached as a
+    // single promise so concurrent calls before the first one resolves
+    // don't race to create the collection twice.
+    this.ready = this.ensureCollection();
+  }
+
+  async ensureCollection() {
+    const has = await this.client.hasCollection({ collection_name: this.collection });
+    if (has.value) {
+      await this.client.loadCollection({ collection_name: this.collection });
+      return;
+    }
+
+    await this.client.createCollection({
+      collection_name: this.collection,
+      fields: [
+        { name: RECORD_ID_FIELD, data_type: DataType.VarChar, is_primary_key: true, type_params: { max_length: 64 } },
+        { name: VECTOR_FIELD, data_type: DataType.FloatVector, type_params: { dim: this.dimension } },
+        { name: "sourceAgent", data_type: DataType.VarChar, type_params: { max_length: 256 } },
+        { name: "sourceDbKind", data_type: DataType.VarChar, type_params: { max_length: 128 } },
+        { name: "createdAt", data_type: DataType.VarChar, type_params: { max_length: 64 } },
+        { name: "ttlEpoch", data_type: DataType.Int64 },
+        {
+          name: "entities",
+          data_type: DataType.Array,
+          element_type: DataType.VarChar,
+          type_params: { max_length: 256, max_capacity: 64 },
+        },
+        { name: "insightSummary", data_type: DataType.VarChar, type_params: { max_length: 2048 } },
+        {
+          name: "suggestedFollowups",
+          data_type: DataType.Array,
+          element_type: DataType.VarChar,
+          type_params: { max_length: 512, max_capacity: 16 },
+        },
+      ],
+    });
+
+    await this.client.createIndex({
+      collection_name: this.collection,
+      field_name: VECTOR_FIELD,
+      index_type: "AUTOINDEX",
+      metric_type: "COSINE",
+    });
+
+    await this.client.loadCollection({ collection_name: this.collection });
+  }
+
+  async put(record, vector) {
+    await this.ready;
+    await this.client.insert({
+      collection_name: this.collection,
+      data: [
+        {
+          [RECORD_ID_FIELD]: record.recordId,
+          [VECTOR_FIELD]: vector,
+          sourceAgent: record.sourceAgent,
+          sourceDbKind: record.sourceDbKind,
+          createdAt: record.createdAt,
+          ttlEpoch: record.ttlEpoch,
+          entities: record.entities || [],
+          insightSummary: record.insightSummary,
+          suggestedFollowups: record.suggestedFollowups || [],
+        },
+      ],
+    });
+  }
+
+  async query(vector, { excludeAgent, topK }) {
+    await this.ready;
+    const now = Math.floor(Date.now() / 1000);
+    const response = await this.client.search({
+      collection_name: this.collection,
+      data: [vector],
+      anns_field: VECTOR_FIELD,
+      metric_type: "COSINE",
+      // Over-fetch and filter excludeAgent/ttl client-side, same reasoning
+      // as S3VectorsBackend — keeps this correct even if a future Milvus
+      // filter-expression edge case doesn't behave the way `filter` expects.
+      limit: Math.max(topK * 4, 10),
+      filter: `ttlEpoch > ${now}`,
+      output_fields: [RECORD_ID_FIELD, ...METADATA_OUTPUT_FIELDS],
+    });
+
+    const records = [];
+    for (const item of response.results || []) {
+      if (item.sourceAgent === excludeAgent) continue;
+      records.push({
+        recordId: item[RECORD_ID_FIELD] ?? item.id,
+        sourceAgent: item.sourceAgent || "",
+        sourceDbKind: item.sourceDbKind || "",
+        createdAt: item.createdAt || "",
+        ttlEpoch: Number(item.ttlEpoch || 0),
+        entities: item.entities || [],
+        insightSummary: item.insightSummary || "",
+        suggestedFollowups: item.suggestedFollowups || [],
+      });
+      if (records.length >= topK) break;
+    }
+    return records;
+  }
+
+  // Same best-effort semantic-lookup design as S3VectorsBackend's version —
+  // see that file's comment for the full reasoning. Re-fetches the original
+  // vector via `get()` (by primary key) rather than reusing the query
+  // vector, so re-inserting via upsert doesn't recenter the record on the
+  // invalidated question's embedding.
+  async invalidateFollowup(questionText, queryVector) {
+    await this.ready;
+    const target = normalizeQuestion(questionText);
+
+    const searchResponse = await this.client.search({
+      collection_name: this.collection,
+      data: [queryVector],
+      anns_field: VECTOR_FIELD,
+      metric_type: "COSINE",
+      limit: 20,
+      output_fields: [RECORD_ID_FIELD, "suggestedFollowups"],
+    });
+
+    const candidateIds = (searchResponse.results || [])
+      .filter((item) => (item.suggestedFollowups || []).some((f) => normalizeQuestion(f) === target))
+      .map((item) => item[RECORD_ID_FIELD] ?? item.id);
+    if (candidateIds.length === 0) return { removed: 0 };
+
+    const getResponse = await this.client.get({
+      collection_name: this.collection,
+      ids: candidateIds,
+      output_fields: [RECORD_ID_FIELD, VECTOR_FIELD, ...METADATA_OUTPUT_FIELDS],
+    });
+
+    let removed = 0;
+    const updates = [];
+    for (const row of getResponse.data || []) {
+      const followups = row.suggestedFollowups || [];
+      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
+      if (filtered.length === followups.length) continue;
+      removed += followups.length - filtered.length;
+      updates.push({
+        [RECORD_ID_FIELD]: row[RECORD_ID_FIELD],
+        [VECTOR_FIELD]: row[VECTOR_FIELD],
+        sourceAgent: row.sourceAgent,
+        sourceDbKind: row.sourceDbKind,
+        createdAt: row.createdAt,
+        ttlEpoch: row.ttlEpoch,
+        entities: row.entities || [],
+        insightSummary: row.insightSummary,
+        suggestedFollowups: filtered,
+      });
+    }
+
+    if (updates.length > 0) {
+      await this.client.upsert({ collection_name: this.collection, data: updates });
+    }
+    return { removed };
+  }
+}

--- a/app/memoryBackends/s3vectors.js
+++ b/app/memoryBackends/s3vectors.js
@@ -1,0 +1,142 @@
+// memoryBackends/s3vectors.js — AWS S3 Vectors (preview).
+// Mirrors ../../core/memory.py's S3VectorsBackend. Bucket + index are
+// expected to already exist — this class only puts/queries, to keep IAM
+// scoped tight. Over-fetches (topK * 4) and filters ttlEpoch/excludeAgent
+// client-side rather than relying on exact metadata-filter operator
+// support — S3 Vectors is a preview service and filter semantics could
+// shift; this stays correct across API changes at the cost of a slightly
+// larger response.
+
+import {
+  S3VectorsClient,
+  PutVectorsCommand,
+  QueryVectorsCommand,
+  GetVectorsCommand,
+} from "@aws-sdk/client-s3vectors";
+import { normalizeQuestion } from "../memory.js";
+
+export class S3VectorsBackend {
+  constructor({ bucket, index, region }) {
+    this.bucket = bucket;
+    this.index = index;
+    this.client = new S3VectorsClient({ region });
+  }
+
+  async put(record, vector) {
+    await this.client.send(
+      new PutVectorsCommand({
+        vectorBucketName: this.bucket,
+        indexName: this.index,
+        vectors: [
+          {
+            key: record.recordId,
+            data: { float32: vector },
+            metadata: {
+              sourceAgent: record.sourceAgent,
+              sourceDbKind: record.sourceDbKind,
+              createdAt: record.createdAt,
+              ttlEpoch: record.ttlEpoch,
+              entities: record.entities,
+              insightSummary: record.insightSummary,
+              suggestedFollowups: record.suggestedFollowups,
+            },
+          },
+        ],
+      })
+    );
+  }
+
+  async query(vector, { excludeAgent, topK }) {
+    const response = await this.client.send(
+      new QueryVectorsCommand({
+        vectorBucketName: this.bucket,
+        indexName: this.index,
+        topK: Math.max(topK * 4, 10),
+        queryVector: { float32: vector },
+        returnMetadata: true,
+        returnDistance: true,
+      })
+    );
+
+    const now = Date.now() / 1000;
+    const records = [];
+    for (const item of response.vectors || []) {
+      const meta = item.metadata || {};
+      if (meta.sourceAgent === excludeAgent) continue;
+      if (Number(meta.ttlEpoch || 0) < now) continue;
+      records.push({
+        recordId: item.key,
+        sourceAgent: meta.sourceAgent || "",
+        sourceDbKind: meta.sourceDbKind || "",
+        createdAt: meta.createdAt || "",
+        ttlEpoch: Number(meta.ttlEpoch || 0),
+        entities: meta.entities || [],
+        insightSummary: meta.insightSummary || "",
+        suggestedFollowups: meta.suggestedFollowups || [],
+      });
+      if (records.length >= topK) break;
+    }
+    return records;
+  }
+
+  // Same intent as LocalJsonBackend.invalidateFollowup, but S3 Vectors has
+  // no "list all" or text-search primitive — only vector similarity search.
+  // So this is a best-effort semantic lookup: it queries near the question's
+  // own embedding (a follow-up question is usually reasonably close to the
+  // insightSummary it was suggested alongside), then does an exact,
+  // normalized string match against the candidates' metadata before
+  // touching anything, so a low-recall miss just means "nothing found",
+  // never a wrong edit. Vector data for a match is re-fetched via
+  // GetVectorsCommand and re-written unchanged — reusing the *query*
+  // vector for the PutVectors overwrite would recenter that memory record
+  // on the invalidated question's embedding instead of its original
+  // insight, corrupting future similarity search for it.
+  async invalidateFollowup(questionText, queryVector) {
+    const target = normalizeQuestion(questionText);
+    const queryResponse = await this.client.send(
+      new QueryVectorsCommand({
+        vectorBucketName: this.bucket,
+        indexName: this.index,
+        topK: 20,
+        queryVector: { float32: queryVector },
+        returnMetadata: true,
+      })
+    );
+
+    const candidateKeys = (queryResponse.vectors || [])
+      .filter((item) => (item.metadata?.suggestedFollowups || []).some((f) => normalizeQuestion(f) === target))
+      .map((item) => item.key);
+    if (candidateKeys.length === 0) return { removed: 0 };
+
+    const getResponse = await this.client.send(
+      new GetVectorsCommand({
+        vectorBucketName: this.bucket,
+        indexName: this.index,
+        keys: candidateKeys,
+        returnData: true,
+        returnMetadata: true,
+      })
+    );
+
+    let removed = 0;
+    const updates = [];
+    for (const item of getResponse.vectors || []) {
+      const followups = item.metadata?.suggestedFollowups || [];
+      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
+      if (filtered.length === followups.length) continue;
+      removed += followups.length - filtered.length;
+      updates.push({
+        key: item.key,
+        data: item.data,
+        metadata: { ...item.metadata, suggestedFollowups: filtered },
+      });
+    }
+
+    if (updates.length > 0) {
+      await this.client.send(
+        new PutVectorsCommand({ vectorBucketName: this.bucket, indexName: this.index, vectors: updates })
+      );
+    }
+    return { removed };
+  }
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,12 +9,51 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3vectors": "^3.1095.0",
+        "@zilliz/milvus2-sdk-node": "^3.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
         "openai": "^4.67.0"
       },
       "engines": {
         "node": ">=22.5.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.22.tgz",
+      "integrity": "sha512-YsSac72lcCOSjk5X4fMc20SjltkGUDjckB2vYZcEd/RpgB+huzeQwVZrOWxUvLVo+5D7X9sURgmAAPmErgCQ7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1097.0.tgz",
+      "integrity": "sha512-iCBD95hrynpxiOzD301pUW9H3mxKcEfMErLqdg58WcIZnEqJuOd7JwcARsV3/y6OWj1t6j2tpS9lGt6X4OnPFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.22",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-node": "^3.972.74",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.68",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3vectors": {
@@ -37,9 +76,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.2.tgz",
+      "integrity": "sha512-8sT/M5vDcagx5/iM0Bfx7f6i3mfVOQkA34+GTMwp0lIWZb6ma+bjkzDS/r9yqU2yTPBqqMBFPT3+d9kUuuNDJA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
@@ -56,12 +95,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.63.tgz",
+      "integrity": "sha512-VSS9dftt7r7GiZ4gs8z0PNaMLVAaSj/MXVr6WQBtsrQQB9miJo7I6lQuJND1/ugFwK9x7OHCYZDkLSYh0FIZtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -72,12 +111,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.65.tgz",
+      "integrity": "sha512-SH/ec7p1J0CfC28+ypH38IwGENd7tQEvTpmuRSlinthiGxKlwzJbXGXxIMAhn0/lpxnIxudNmCsw3Cy0PDRoAg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/fetch-http-handler": "^5.6.10",
@@ -90,19 +129,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.8.tgz",
+      "integrity": "sha512-alkQpDUHsjHGVXvlV0XFXpPfh9+aTMmN6UYRky0Qky8SbvdxoQdDHftT4uugq8XShP6WtDQW7bo5YQ0SfNSxRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-login": "^3.972.68",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-login": "^3.972.70",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/credential-provider-imds": "^4.4.13",
@@ -114,13 +153,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.70.tgz",
+      "integrity": "sha512-JlUjK6bYJAxN9PkWWCI/TiOYEdvXNKq61x2DTaEKxRMxAOYNk2LX8m4wVtDFxTZwyXx7Tpmxb49dNprkW/uqXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -131,17 +170,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.74.tgz",
+      "integrity": "sha512-V+7pzT0OzROL2uKcQ2+MpnfwKONvozYojmdn8RguAMX9o48gtSVvt+7aCkwWCH2thDXOnUPCN6qn4kiFDelZWA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-ini": "^3.973.6",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/credential-provider-env": "^3.972.63",
+        "@aws-sdk/credential-provider-http": "^3.972.65",
+        "@aws-sdk/credential-provider-ini": "^3.973.8",
+        "@aws-sdk/credential-provider-process": "^3.972.63",
+        "@aws-sdk/credential-provider-sso": "^3.973.7",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.69",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/credential-provider-imds": "^4.4.13",
@@ -153,12 +192,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "version": "3.972.63",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.63.tgz",
+      "integrity": "sha512-lPt2oGMcvP3uPhhxX5EquHrzBI/ZgJce+CHKcOGZl2ZQAXLLSxu7k/Cgo0HIktyi9dmDFljbOkj4XAnXD93YVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -169,14 +208,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.7.tgz",
+      "integrity": "sha512-FR2b+7QNXP/q+eslVzrCjGKvso8Lcr/B18BvFyD2iLNhq42XSo+wnh8FfX6mtqgaVsL1vuB27uGXuY+xUTa7pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
-        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/token-providers": "3.1097.0",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -187,13 +226,30 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.69.tgz",
+      "integrity": "sha512-RWNTKGXRkzMJe8bgIAdlz9q0N97m7fThD9KOjBt2CSY+/xnIbrA1/Dnm/ZEz8ZeQ1Of5D+fLaPeoD3lGt6AU4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.68.tgz",
+      "integrity": "sha512-JA/LRxCSXQAsFHyIZzgncYdcTQTOL3ZS8R7EAeDwoSoWcNG8yxDAacrwFTZIyVSMvkogvlKHRvmrMU68UyQbkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -204,12 +260,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "version": "3.997.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.37.tgz",
+      "integrity": "sha512-vfDmA6APjX1LWxvt6/zcAmTCgRXCj35M+bC9Ujmy40QxYs9Fa9bE7oblOB3ODZ4mdN9R5osU0hTzoJjJlQqqTg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.2",
         "@aws-sdk/signature-v4-multi-region": "^3.996.42",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
@@ -238,13 +294,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "version": "3.1097.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1097.0.tgz",
+      "integrity": "sha512-EIsdmy/f5IGc5r01RjKWNvrbBra6z0xudQM0D6Wf8DeGuPoRlubkLqr7VgWijFucO4kg0mtev9H3RX/ZOubUhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.2",
+        "@aws-sdk/nested-clients": "^3.997.37",
         "@aws-sdk/types": "^3.974.2",
         "@smithy/core": "^3.29.8",
         "@smithy/types": "^4.16.1",
@@ -289,10 +345,167 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@shanghaikid/parquetjs": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@shanghaikid/parquetjs/-/parquetjs-1.8.8.tgz",
+      "integrity": "sha512-uaYXx4yP4cipVU8EZR4OZohiklsazyAcIXtfNEEYBcsMlnz5w4gEvv9vw+cP3yZBv7d1+OQYKfCfKI7oK0iUZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.864.0",
+        "@types/node-int64": "^0.4.32",
+        "@types/thrift": "^0.10.17",
+        "@zenfs/core": "^2.3.8",
+        "brotli-wasm": "^3.0.1",
+        "bson": "6.10.4",
+        "int53": "^1.0.0",
+        "long": "^5.3.2",
+        "node-int64": "^0.4.0",
+        "snappyjs": "^0.7.0",
+        "thrift": "0.23.0",
+        "varint": "^6.0.0",
+        "xxhash-wasm": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.18.2"
+      }
+    },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -303,12 +516,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -370,6 +583,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@types/node": {
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
@@ -387,6 +610,105 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/node-int64": {
+      "version": "0.4.32",
+      "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.32.tgz",
+      "integrity": "sha512-xf/JsSlnXQ+mzvc0IpXemcrO4BrCfpgNpMco+GLcXkFk01k/gW9lGJu+Vof0ZSvHK6DsHJDPSbjFPs36QkWXqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/q": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
+      "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/thrift": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.17.tgz",
+      "integrity": "sha512-bDX6d5a5ZDWC81tgDv224n/3PKNYfIQJTPHzlbk4vBWJrYXF6Tg1ncaVmP/c3JbGN2AK9p7zmHorJC2D6oejGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/node-int64": "*",
+        "@types/q": "*"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
+      "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@zenfs/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@zenfs/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-wnQqExW07m1MfY8T4eVI4Je9sFmOUeXvYCSJZ1cSfKU5VfTCl8qo+M7PDndHj/3QTXx8cD8jShwWTbV99A5hbQ==",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "@types/node": "^25.2.0",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "kerium": "^1.4.2",
+        "memium": "^0.4.0",
+        "readable-stream": "^4.5.2",
+        "utilium": "^3.0.0"
+      },
+      "bin": {
+        "make-index": "scripts/make-index.js",
+        "zci": "scripts/ci-cli.js",
+        "zenfs-test": "scripts/test.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
+      }
+    },
+    "node_modules/@zenfs/core/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@zenfs/core/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/@zilliz/milvus2-sdk-node": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@zilliz/milvus2-sdk-node/-/milvus2-sdk-node-3.0.3.tgz",
+      "integrity": "sha512-7rC+MDmzfctc9wscIfqxkzTJCxWafSdkyFDESMIzEX1G2ndImRQzHfkrzjcPFqPBVgQHQScGnGa3W7edqcThjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.3",
+        "@grpc/proto-loader": "^0.8.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@petamoriken/float16": "^3.8.6",
+        "@shanghaikid/parquetjs": "1.8.8",
+        "dayjs": "^1.11.7",
+        "generic-pool": "^3.9.0",
+        "lru-cache": "^9.1.2",
+        "protobufjs": "^7.5.8",
+        "winston": "^3.9.0"
       }
     },
     "node_modules/abort-controller": {
@@ -426,16 +748,90 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -467,6 +863,54 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brotli-wasm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
+      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=v18.0.0"
+      }
+    },
+    "node_modules/browser-or-node": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
+      "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
+      "license": "MIT"
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -504,6 +948,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/combined-stream": {
@@ -552,6 +1056,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -623,6 +1133,18 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -677,6 +1199,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -699,6 +1230,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -747,6 +1293,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -764,6 +1316,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/form-data": {
       "version": "4.0.6",
@@ -825,6 +1383,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -956,11 +1532,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/int53": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/int53/-/int53-1.0.0.tgz",
+      "integrity": "sha512-u8BMiMa05OPBgd32CKTead0CVTsFVgwFk23nNXo1teKPF6Sxcu0lXxEzP//zTcaKzXbGgPDXGmj/woyv+I4C5w==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -969,6 +1571,99 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/kerium": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/kerium/-/kerium-1.4.2.tgz",
+      "integrity": "sha512-K2gshjNgxuG4tE+hAnCS7HEWhu/JEobNh52rSLDR4Vu8Vxi5f+K9U8h3+9P4JWvaw/IL4Orfd+9mufhVtrl3lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "utilium": "^3.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-9.1.2.tgz",
+      "integrity": "sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/math-intrinsics": {
@@ -987,6 +1682,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/memium": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/memium/-/memium-0.4.5.tgz",
+      "integrity": "sha512-mnmHWWlcyKnkKSSU0qL1Jsg+CsoikVZ2xsOatAN89R+j4V3m3WlQr0nUoqcjKDyUVF5ZGdNinRiZGVd+7A+TJQ==",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "kerium": "^1.3.2",
+        "utilium": "^3.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
       }
     },
     "node_modules/merge-descriptors": {
@@ -1095,6 +1804,12 @@
         }
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1117,6 +1832,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/openai": {
@@ -1164,6 +1888,38 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1175,6 +1931,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -1217,6 +1984,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -1236,6 +2028,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1366,6 +2167,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/snappyjs": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.7.0.tgz",
+      "integrity": "sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==",
+      "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1373,6 +2189,73 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
+    "node_modules/thrift": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.23.0.tgz",
+      "integrity": "sha512-j7F1ls8JogClU88Ta/pwD/OzYuiFeD6Z5GoWw7ip+jcDhcNYFKgfXYEsyLXYpiNfJO94fbLnITGxyfZ19YzA6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "browser-or-node": "^1.2.1",
+        "isomorphic-ws": "^4.0.1",
+        "node-int64": "^0.4.0",
+        "q": "^1.5.0",
+        "uuid": "^13.0.0",
+        "ws": "^5.2.3"
+      },
+      "engines": {
+        "node": ">= 10.18.0"
+      }
+    },
+    "node_modules/thrift/node_modules/ws": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.7.tgz",
+      "integrity": "sha512-Yp1RXz/2h2qC/Gy7d5mqQcpuCWbXiO6FgYw/jTbSvytZF9wD7fh7od+6WzWR/y9EAnXcJjQZpPkYVmj3T2bj+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "async-limiter": "~1.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1389,6 +2272,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -1424,6 +2316,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utilium": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/utilium/-/utilium-3.4.1.tgz",
+      "integrity": "sha512-vTun2pro1zvmuMa1a9GuGY2iag/PZSHwo5WSWuUvsZBc1deFwO2wcgkV/J0xsi/A3vwzs91psYTunR4mvCa7fg==",
+      "license": "LGPL-3.0-or-later",
+      "dependencies": {
+        "eventemitter3": "^5.0.1"
+      },
+      "bin": {
+        "lice": "scripts/lice.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/james-pre"
+      },
+      "optionalDependencies": {
+        "@xterm/xterm": "^5.5.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1432,6 +2352,25 @@
       "engines": {
         "node": ">= 0.4.0"
       }
+    },
+    "node_modules/uuid": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -1465,6 +2404,151 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xxhash-wasm": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
+      "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
+      "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3vectors": "^3.1095.0",
+    "@zilliz/milvus2-sdk-node": "^3.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
     "openai": "^4.67.0"

--- a/app/server.js
+++ b/app/server.js
@@ -13,13 +13,8 @@ import OpenAI from "openai";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  LocalJsonBackend,
-  S3VectorsBackend,
-  fetchRelevantMemories,
-  invalidateFollowup,
-  writeMemory,
-} from "./memory.js";
+import { fetchRelevantMemories, invalidateFollowup, writeMemory } from "./memory.js";
+import { createMemoryBackend, listMemoryBackends } from "./memoryBackends/index.js";
 import { formatKnowledge, loadKnowledge, selectRelevantKnowledge } from "./knowledge.js";
 import { validateSql } from "./sqlSafety.js";
 import { benchmarkStore } from "./benchmarks.js";
@@ -60,19 +55,17 @@ const EMBEDDING_BASE_URL = process.env.EMBEDDING_BASE_URL || LLM_BASE_URL;
 const EMBEDDING_API_KEY = process.env.EMBEDDING_API_KEY || LLM_API_KEY;
 
 // ── Cross-platform contextual memory config ─────────────────────────────────
-// MEMORY_BACKEND=local (default, no cloud setup) or s3vectors (requires
-// MEMORY_S3_BUCKET + MEMORY_ORG_ID + a pre-provisioned vector bucket/index —
-// see app/README.md).
-const memoryBackend =
-  (process.env.MEMORY_BACKEND || "local").toLowerCase() === "s3vectors"
-    ? new S3VectorsBackend({
-        bucket: process.env.MEMORY_S3_BUCKET || "",
-        index: process.env.MEMORY_ORG_ID || "demo-org",
-        region: process.env.MEMORY_S3_REGION || "us-east-1",
-      })
-    : new LocalJsonBackend(
-        process.env.MEMORY_STORE_PATH || path.join(__dirname, "data", "memory_store.jsonl")
-      );
+// MEMORY_BACKEND selects the storage backend from the pluggable registry in
+// memoryBackends/index.js — "local" (default, no cloud setup), "s3vectors"
+// (AWS S3 Vectors, requires MEMORY_S3_BUCKET + MEMORY_ORG_ID + a
+// pre-provisioned vector bucket/index), or "milvus" (self-hosted or Zilliz
+// Cloud, requires MILVUS_ADDRESS + MEMORY_VECTOR_DIM matching
+// EMBEDDING_MODEL's output dimension) — see app/README.md. Adding a new
+// backend means adding one entry to that registry, not touching this file.
+const memoryBackend = createMemoryBackend(process.env.MEMORY_BACKEND, {
+  env: process.env,
+  dataDir: path.join(__dirname, "data"),
+});
 
 const db = new DatabaseSync(DB_PATH, { readOnly: false });
 const llm = new OpenAI({ baseURL: LLM_BASE_URL, apiKey: LLM_API_KEY });
@@ -492,6 +485,7 @@ app.get("/api/config", (req, res) => {
     memoryEnabled: MEMORY.memoryEnabled,
     dbagentId: MEMORY.dbagentId,
     memoryBackend: process.env.MEMORY_BACKEND || "local",
+    availableMemoryBackends: listMemoryBackends(),
     embeddingBaseUrl: EMBEDDING_BASE_URL,
     embeddingModel: MEMORY.embeddingModel,
     knowledgeLoaded: loadKnowledge(KNOWLEDGE_PATH) !== null,


### PR DESCRIPTION
## Summary
- Splits memory backend selection (previously an inline local/s3vectors ternary in `server.js`) into a proper registry, `memoryBackends/index.js` — `createMemoryBackend(name, {env, dataDir})`, mirrors the pattern used elsewhere in this repo
- `LocalJsonBackend`/`S3VectorsBackend` move into their own files under `memoryBackends/`, unchanged; `memory.js` keeps only the backend-agnostic parts (summarization, embedding, the public write/fetch/invalidate API)
- Adds `MilvusBackend` (self-hosted or Zilliz Cloud) — verified against the installed `@zilliz/milvus2-sdk-node` v3 type definitions directly rather than guessed, since that package's API has shifted across majors. Auto-creates its collection/index on first use (unlike S3 Vectors, which needs out-of-band provisioning) since Milvus is commonly self-hosted for local/dev use
- Adding a future backend now means one new file + one registry entry; nothing in `server.js` changes

## Test plan
- [x] `node --check` on all changed/new files
- [x] `npm run benchmark` — 7/7 seed cases pass against local Ollama (fresh `npm install`, confirms no regression from the refactor)
- [x] Verified no AWS bucket names/ARNs/tokens present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)