### PR TITLE
Add a pluggable SQL engine layer and a MinIO/DuckDB-backed data source

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -11,6 +11,20 @@ LLM_BASE_URL=http://localhost:11434/v1
 LLM_API_KEY=ollama
 LLM_MODEL=qwen2.5-coder:7b
 
+# ── SQL engine ───────────────────────────────────────────────────────────────
+# SQL_ENGINE=sqlite (default, DB_PATH above) or minio-duckdb (Parquet objects
+# in MinIO/any S3-compatible store, queried via DuckDB's httpfs extension —
+# see app/README.md's "MinIO / DuckDB SQL engine" section, and
+# scripts/seed-minio-demo.js for a one-command local demo dataset).
+# SQL_ENGINE=minio-duckdb
+# MINIO_ENDPOINT=localhost:9000       # host:port, no http(s):// prefix
+# MINIO_BUCKET=demo-bucket
+# MINIO_PREFIX=db-agent-demo          # objects under bucket/prefix/*.parquet become tables
+# MINIO_ACCESS_KEY=minioadmin
+# MINIO_SECRET_KEY=minioadmin
+# MINIO_USE_SSL=false
+# MINIO_REGION=us-east-1              # arbitrary for MinIO, still required for SigV4
+
 # ── Cross-platform contextual memory ────────────────────────────────────────
 # Unique per running instance — tags writes, excludes self on reads.
 DBAGENT_ID=local

--- a/app/README.md
+++ b/app/README.md
@@ -6,10 +6,13 @@ Streamlit app — built to compare how the UI feels on a real frontend stack
 model and widget styling. See the root `README.md` for background on the
 project.
 
-Scope is intentionally narrower than the Python app in one respect: SQLite
-only, a single LLM (no model failover chain, no Databricks-native SQL
-backend). It does carry over the SQL repair-on-failure loop and the
-cross-platform contextual memory feature — see Notes below.
+Scope is intentionally narrower than the Python app in one respect: a
+single LLM (no model failover chain, no Databricks-native SQL backend). It
+does carry over the SQL repair-on-failure loop and the cross-platform
+contextual memory feature. The SQL layer itself is pluggable
+(`sqlEngines/`, same registry pattern as the memory backends): `sqlite`
+(default, a local file) or `minio-duckdb` (Parquet objects in MinIO/any
+S3-compatible store, via DuckDB) — see Notes below.
 
 Two parts:
 - `server.js` / `memory.js` — Express API (`/api/schema`, `/api/config`,
@@ -69,7 +72,66 @@ documented-supported) — the deployment shape is the same generic
 - Mirrors `../core/sql_safety.py`'s safety rules and `../core/pipeline.py`'s
   SQL repair-on-failure loop (failed execution → error fed back to the LLM →
   re-validated before retrying) — same behavior, ported by hand since this is
-  a separate runtime, not a shared library.
+  a separate runtime, not a shared library. `sqlSafety.js`'s validator runs
+  identically regardless of which SQL engine is active (see below) — it
+  gates the SQL string itself, before any engine ever sees it.
+- **Pluggable SQL engines** (`sqlEngines/`): the same registry pattern as
+  the memory backends below — `getSchema()`/`runQuery()` behind one
+  interface, selected via `SQL_ENGINE`, adding a new one means one new file
+  plus one registry entry, nothing in `server.js` changes.
+  - `sqlite` (default) — Node's built-in `node:sqlite` module (stable in
+    Node ≥ 22.5) against `DB_PATH` (a local file, `./data/demo.db` by
+    default) — no native build step, unlike `better-sqlite3`.
+  - `minio-duckdb` — Parquet objects in MinIO (or any S3-compatible object
+    store), queried through [DuckDB](https://duckdb.org)'s `httpfs`
+    extension. MinIO holds no live database here, just Parquet files under
+    a bucket/prefix; DuckDB is the query engine. **Verified end-to-end
+    against a real local MinIO instance** (Docker, not mocked): schema
+    introspection, a multi-table join, and the repair loop's error-catching
+    path all confirmed working.
+
+    Convention: every `<bucket>/<prefix>/<table>.parquet` object becomes one
+    logical table named `<table>`, exposed as a DuckDB view over
+    `read_parquet()` — the LLM's generated SQL never needs to know an S3
+    path or Parquet is involved, it just sees table names like any other
+    engine. **Partitioned or multi-file-per-table datasets aren't supported
+    in this first pass** — each table must be exactly one Parquet object.
+    Iceberg table support (DuckDB has an `iceberg` extension, and MinIO's
+    AIStor product supports Iceberg-backed tables natively) is a natural
+    next step but isn't wired up yet.
+
+    Requires `MINIO_ENDPOINT` + `MINIO_BUCKET` (see `.env.example`); tables
+    are discovered once at startup via `glob()`, so adding/removing a
+    Parquet object under the prefix needs a server restart to pick up —
+    not re-scanned per request. `s3_url_style` is forced to `path`, which
+    MinIO (and most self-hosted S3-compatible stores) require — AWS S3
+    itself defaults to virtual-hosted style, which is why this isn't
+    DuckDB's own default.
+
+    **Caveat found while testing**: DuckDB's `BIGINT` columns (which is what
+    `COUNT(*)`/integer aggregates come back as) are returned as JSON
+    *strings*, not native JSON numbers, in query results — a raw JS
+    `bigint` isn't valid input to `JSON.stringify` (which `res.json()` uses
+    under the hood), so the DuckDB Node API stringifies rather than crash
+    the response. `DOUBLE` columns (e.g. `SUM(price)`) come back as normal
+    numbers. Something to know if you're formatting result values on the
+    frontend.
+
+    **Quick local demo** (for a live walkthrough, not just a smoke test):
+    ```bash
+    cd app
+    docker compose -f scripts/minio-demo-compose.yml up -d   # real MinIO, localhost:9000/9001
+    node scripts/seed-minio-demo.js                            # exports data/demo.db -> Parquet -> uploads to MinIO
+    SQL_ENGINE=minio-duckdb MINIO_ENDPOINT=localhost:9000 MINIO_BUCKET=demo-bucket \
+      MINIO_PREFIX=db-agent-demo MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin \
+      MINIO_USE_SSL=false ./run_local.sh
+    ```
+    Seeds the same customers/products/orders demo domain as the SQLite
+    default (exported via DuckDB's `sqlite` extension, so no separate
+    dataset to maintain) — ask it the same questions you'd ask the SQLite
+    demo and compare. MinIO console at `http://localhost:9001`
+    (`minioadmin`/`minioadmin`) if you want to browse the uploaded Parquet
+    objects visually mid-demo.
 - **Optional knowledge file** (`knowledge.js`, `knowledge.json`): the schema
   alone (table/column names + types) doesn't carry business terminology,
   ambiguous-column meaning, or house rules — this is where those go. Copy

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-s3vectors": "^3.1095.0",
+        "@duckdb/node-api": "^1.5.5-r.2",
         "@zilliz/milvus2-sdk-node": "^3.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
@@ -364,6 +365,150 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@duckdb/node-api": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.5.5-r.3.tgz",
+      "integrity": "sha512-qOwoSj8eBW+mNyAvTOOWjnii6jwrLkQFbEC/TyYGZjYCAQzu1r1X6UWVo+23sgtGGNHxmJLHE0ms5QtlQf2W3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.5.5-r.3"
+      }
+    },
+    "node_modules/@duckdb/node-bindings": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.5.5-r.3.tgz",
+      "integrity": "sha512-I5basCuPs0OrNHu2cDLFrIErp6Rr9J7wR5awVbvCmFQdOCpi+v+lmQy6KZ2dH8Z7hsqwmAMHk/QJ0s5cvW0qnw==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.5.5-r.3",
+        "@duckdb/node-bindings-darwin-x64": "1.5.5-r.3",
+        "@duckdb/node-bindings-linux-arm64": "1.5.5-r.3",
+        "@duckdb/node-bindings-linux-arm64-musl": "1.5.5-r.3",
+        "@duckdb/node-bindings-linux-x64": "1.5.5-r.3",
+        "@duckdb/node-bindings-linux-x64-musl": "1.5.5-r.3",
+        "@duckdb/node-bindings-win32-arm64": "1.5.5-r.3",
+        "@duckdb/node-bindings-win32-x64": "1.5.5-r.3"
+      }
+    },
+    "node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.5-r.3.tgz",
+      "integrity": "sha512-bqnjnI2U/aUOcB25smNRwxF1/47HxHz78a8F9ghTHvEl+CeEMEr1lp+sPmjuS/1EybAYsaWJro6zFLd+O5qNQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.5-r.3.tgz",
+      "integrity": "sha512-8QEA0tuW5EWPg7kQbyWka6kGu+j7wZuvUAkibdJgODtxz4axJGMR5oM13lb6m/HedvsU3ch2lkvhIhwv6aWqsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.5-r.3.tgz",
+      "integrity": "sha512-27y+0xn4ad6mirnu3faZUE2UQhvpPTpi/o9tm9cGxi7QvuvhfD5rvo0D3RnhreHTjiYB4RRB5ZqPMRErqOaTlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-arm64-musl": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64-musl/-/node-bindings-linux-arm64-musl-1.5.5-r.3.tgz",
+      "integrity": "sha512-qETa9eqdZQNNn1QFfW+FI91HM5kVm+tN4cfqBPu1FgRTatd0oG8KPOfl6NlpuKhQQM5TcWDxI3P57JPXbzjsEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.5-r.3.tgz",
+      "integrity": "sha512-+n/rmU0o3Km5MEBJnjteud8f5JEhcSPxTdcyxNERL6H3pZw1vQX3ysI1axP8Mx0Mw7XrVv9+pC5VH+9ERD3LQg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-linux-x64-musl": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64-musl/-/node-bindings-linux-x64-musl-1.5.5-r.3.tgz",
+      "integrity": "sha512-+9cThIhSC1inv6MVVgL37k4lRk56uo7TK2MLNwn1xe7mDVOh8SsjZbHLd/IZ0cWJn77lX7/6G3Qz3mU5k4O2PA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-arm64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.5-r.3.tgz",
+      "integrity": "sha512-/9Ji9xKtzar7MM21DJMZfuizOXjdar+JtOez6o3ue7cKt0AUpjLjqbAjQ0sE/pkqMbByv9TEiVkTi1b3VYm1dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.5.5-r.3",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.5-r.3.tgz",
+      "integrity": "sha512-NTODIfgfKARm86kOgSW5CvFElE3J+3X0Y0+3Y40P3biO4wrg4FBGtNSCaVyKuWe+CBkA5PODjgIo3w07hu5qrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
@@ -1099,6 +1244,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3vectors": "^3.1095.0",
+    "@duckdb/node-api": "^1.5.5-r.2",
     "@zilliz/milvus2-sdk-node": "^3.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",

--- a/app/scripts/minio-demo-compose.yml
+++ b/app/scripts/minio-demo-compose.yml
@@ -1,0 +1,30 @@
+# docker-compose for the minio-duckdb SQL engine demo — see
+# scripts/seed-minio-demo.js and app/README.md's "MinIO / DuckDB SQL engine"
+# section for the full walkthrough.
+#
+#   cd app/scripts
+#   docker compose -f minio-demo-compose.yml up -d
+#   cd .. && node scripts/seed-minio-demo.js
+#   SQL_ENGINE=minio-duckdb MINIO_ENDPOINT=localhost:9000 MINIO_BUCKET=demo-bucket \
+#     MINIO_PREFIX=db-agent-demo MINIO_ACCESS_KEY=minioadmin MINIO_SECRET_KEY=minioadmin \
+#     MINIO_USE_SSL=false ./run_local.sh
+#
+# Console at http://localhost:9001 (minioadmin / minioadmin) if you want to
+# browse the uploaded Parquet objects visually during a demo.
+
+services:
+  minio:
+    image: minio/minio
+    container_name: dbagent-minio-demo
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/app/scripts/seed-minio-demo.js
+++ b/app/scripts/seed-minio-demo.js
@@ -1,0 +1,114 @@
+// scripts/seed-minio-demo.js — builds the demo dataset for the
+// minio-duckdb SQL engine: exports the bundled SQLite demo.db's tables to
+// Parquet (via DuckDB's sqlite extension, so no separate export tooling is
+// needed) and uploads them to a running MinIO instance (via DuckDB's own
+// S3 write support, so no `mc`/AWS CLI install is needed either).
+//
+// Same demo domain (customers/products/orders) as the SQLite default, on
+// purpose — makes it easy to ask the same benchmark questions against
+// either engine and compare, and means this needs zero new demo data design.
+//
+// Requires a running MinIO instance — see scripts/minio-demo-compose.yml:
+//   docker compose -f scripts/minio-demo-compose.yml up -d
+//   node scripts/seed-minio-demo.js
+//
+// Bucket must already exist (DuckDB's S3 writer doesn't create buckets).
+// Defaults below match minio-demo-compose.yml's minioadmin/minioadmin and
+// the bucket this script creates via the MinIO S3 API directly.
+
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { DuckDBInstance } from "@duckdb/node-api";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const DB_PATH = process.env.DB_PATH || path.join(__dirname, "..", "data", "demo.db");
+const MINIO_ENDPOINT = process.env.MINIO_ENDPOINT || "localhost:9000";
+const MINIO_BUCKET = process.env.MINIO_BUCKET || "demo-bucket";
+const MINIO_PREFIX = process.env.MINIO_PREFIX || "db-agent-demo";
+const MINIO_ACCESS_KEY = process.env.MINIO_ACCESS_KEY || "minioadmin";
+const MINIO_SECRET_KEY = process.env.MINIO_SECRET_KEY || "minioadmin";
+const MINIO_USE_SSL = (process.env.MINIO_USE_SSL || "false").toLowerCase() === "true";
+const TABLES = ["customers", "products", "orders"];
+
+function mcCommand(cmd) {
+  const scheme = MINIO_USE_SSL ? "https" : "http";
+  return (
+    `mc alias set local ${scheme}://${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} ` +
+    `>/dev/null && ${cmd}`
+  );
+}
+
+// DuckDB's S3 writer needs the bucket to already exist — it can write
+// objects but has no "create bucket" operation, and MinIO's bucket-creation
+// endpoint requires a properly SigV4-signed request, which isn't worth
+// hand-rolling here when the official minio/mc image already does it
+// correctly. Shells out to a throwaway `minio/mc` container rather than
+// requiring `mc` installed on the host, same reasoning as
+// minio-demo-compose.yml using a container for MinIO itself: nothing extra
+// to install beyond Docker, which running the demo at all already assumes.
+function ensureBucket() {
+  try {
+    execSync(`docker run --rm --network host --entrypoint /bin/sh minio/mc -c "${mcCommand(`mc mb -p local/${MINIO_BUCKET}`)}"`, {
+      stdio: "pipe",
+    });
+    return true;
+  } catch (exc) {
+    console.warn(
+      `[seed-minio-demo] Could not create bucket "${MINIO_BUCKET}" automatically (${exc.message.split("\n")[0]}). ` +
+        `Create it manually, then re-run this script:\n` +
+        `  docker run --rm --network host --entrypoint /bin/sh minio/mc -c \\\n` +
+        `    "mc alias set local http://${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} && mc mb local/${MINIO_BUCKET}"`
+    );
+    return false;
+  }
+}
+
+async function main() {
+  console.log(`Exporting ${TABLES.join(", ")} from ${DB_PATH} and uploading to ` +
+    `${MINIO_USE_SSL ? "https" : "http"}://${MINIO_ENDPOINT}/${MINIO_BUCKET}/${MINIO_PREFIX}/ ...`);
+
+  const bucketReady = await ensureBucket();
+  if (!bucketReady) {
+    console.warn(
+      `[seed-minio-demo] Could not confirm bucket "${MINIO_BUCKET}" exists via a plain PUT ` +
+        `(MinIO's default config often requires an authenticated request for this). If the ` +
+        `upload below fails with "NoSuchBucket", create it first:\n` +
+        `  docker run --rm --network host --entrypoint /bin/sh minio/mc -c \\\n` +
+        `    "mc alias set local http://${MINIO_ENDPOINT} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} && mc mb local/${MINIO_BUCKET}"`
+    );
+  }
+
+  const instance = await DuckDBInstance.create();
+  const conn = await instance.connect();
+
+  await conn.run("INSTALL sqlite; LOAD sqlite; INSTALL httpfs; LOAD httpfs;");
+  await conn.run(`ATTACH '${DB_PATH.replaceAll("'", "''")}' AS demo (TYPE sqlite);`);
+  await conn.run(`
+    SET s3_endpoint='${MINIO_ENDPOINT.replaceAll("'", "''")}';
+    SET s3_access_key_id='${MINIO_ACCESS_KEY.replaceAll("'", "''")}';
+    SET s3_secret_access_key='${MINIO_SECRET_KEY.replaceAll("'", "''")}';
+    SET s3_url_style='path';
+    SET s3_use_ssl=${MINIO_USE_SSL ? "true" : "false"};
+    SET s3_region='us-east-1';
+  `);
+
+  for (const table of TABLES) {
+    const dest = `s3://${MINIO_BUCKET}/${MINIO_PREFIX}/${table}.parquet`;
+    await conn.run(`COPY demo.${table} TO '${dest}' (FORMAT parquet);`);
+    console.log(`  uploaded ${table} -> ${dest}`);
+  }
+
+  console.log(
+    `\nDone. Point db-agent at it with:\n` +
+      `  SQL_ENGINE=minio-duckdb MINIO_ENDPOINT=${MINIO_ENDPOINT} MINIO_BUCKET=${MINIO_BUCKET} \\\n` +
+      `    MINIO_PREFIX=${MINIO_PREFIX} MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY} MINIO_SECRET_KEY=${MINIO_SECRET_KEY} \\\n` +
+      `    MINIO_USE_SSL=${MINIO_USE_SSL} ./run_local.sh`
+  );
+}
+
+main().catch((exc) => {
+  console.error(`Seeding failed: ${exc.message || exc}`);
+  process.exit(1);
+});

--- a/app/server.js
+++ b/app/server.js
@@ -8,13 +8,13 @@
 
 import "dotenv/config";
 import express from "express";
-import { DatabaseSync } from "node:sqlite";
 import OpenAI from "openai";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { fetchRelevantMemories, invalidateFollowup, writeMemory } from "./memory.js";
 import { createMemoryBackend, listMemoryBackends } from "./memoryBackends/index.js";
+import { createSqlEngine, listSqlEngines } from "./sqlEngines/index.js";
 import { formatKnowledge, loadKnowledge, selectRelevantKnowledge } from "./knowledge.js";
 import { validateSql } from "./sqlSafety.js";
 import { benchmarkStore } from "./benchmarks.js";
@@ -67,7 +67,18 @@ const memoryBackend = createMemoryBackend(process.env.MEMORY_BACKEND, {
   dataDir: path.join(__dirname, "data"),
 });
 
-const db = new DatabaseSync(DB_PATH, { readOnly: false });
+// ── SQL engine config ────────────────────────────────────────────────────────
+// SQL_ENGINE selects the query engine from the pluggable registry in
+// sqlEngines/index.js — "sqlite" (default, local file, zero config) or
+// "minio-duckdb" (Parquet objects in MinIO/any S3-compatible store, queried
+// via DuckDB — requires MINIO_ENDPOINT + MINIO_BUCKET, see app/README.md).
+// Adding a new engine means adding one entry to that registry, not touching
+// this file.
+const sqlEngine = createSqlEngine(process.env.SQL_ENGINE, {
+  env: process.env,
+  dataDir: path.join(__dirname, "data"),
+});
+
 const llm = new OpenAI({ baseURL: LLM_BASE_URL, apiKey: LLM_API_KEY });
 const embeddingClient = new OpenAI({ baseURL: EMBEDDING_BASE_URL, apiKey: EMBEDDING_API_KEY });
 
@@ -83,89 +94,14 @@ const MEMORY = {
 };
 
 // ── Schema introspection ─────────────────────────────────────────────────────
+// Delegated to the active sqlEngine (see sqlEngines/index.js) — schema shape
+// and PII-aware sample-value logic now live per-engine (sqlEngines/sqlite.js
+// has the full PII/sampling implementation; sqlEngines/minioDuckdb.js
+// doesn't sample values in this first pass). async because not every engine
+// can answer synchronously (minio-duckdb awaits DuckDB's httpfs setup).
 
-// The LLM guesses literal column values ("status = 'Pending'" when the data
-// stores 'pending'), returning zero rows with no error — one of the most
-// common real-world text-to-SQL failures. Sampling distinct values for
-// low-cardinality TEXT columns and showing them in the schema fixes this
-// automatically, no config needed.
-const MAX_DISTINCT_VALUES = 10;
-// Skip columns whose name suggests personal data even if low-cardinality —
-// sampling exists to disambiguate enum-like columns, not to leak literal
-// customer data into every prompt. These patterns are unambiguous on their
-// own regardless of table.
-const PII_ALWAYS_PATTERNS = [
-  "email", "phone", "address", "ssn", "password", "secret", "token", "dob", "birth",
-];
-// "name" alone is ambiguous — customers.name is a person's name (PII),
-// products.name is not. Only treat *_name columns as PII when the table
-// itself looks like it holds people.
-const PERSON_TABLE_PATTERNS = [
-  "customer", "user", "person", "employee", "contact", "client", "patient", "student", "member",
-];
-
-function looksLikePII(table, columnName) {
-  const lowerCol = columnName.toLowerCase();
-  if (PII_ALWAYS_PATTERNS.some((p) => lowerCol.includes(p))) return true;
-  if (lowerCol.includes("name")) {
-    const lowerTable = table.toLowerCase();
-    return PERSON_TABLE_PATTERNS.some((p) => lowerTable.includes(p));
-  }
-  return false;
-}
-
-// Cached for the process lifetime rather than re-sampled every request —
-// the schema itself is read fresh each time (cheap PRAGMA calls), but
-// sampling adds a real query per eligible column, and the underlying data
-// doesn't change from a user's perspective the way a knowledge.json edit
-// would. A server restart clears it.
-const columnValueCache = new Map();
-
-function sampleColumnValues(table, column) {
-  const cacheKey = `${table}.${column}`;
-  if (columnValueCache.has(cacheKey)) return columnValueCache.get(cacheKey);
-
-  let values = null;
-  try {
-    const safeTable = `"${table.replaceAll('"', '""')}"`;
-    const safeColumn = `"${column.replaceAll('"', '""')}"`;
-    const rows = db
-      .prepare(
-        `SELECT DISTINCT ${safeColumn} AS v FROM ${safeTable} WHERE ${safeColumn} IS NOT NULL LIMIT ${MAX_DISTINCT_VALUES + 1}`
-      )
-      .all();
-    // Hitting the +1 limit means the column is higher-cardinality than
-    // "enum-like" — skip it rather than show a truncated, misleading list.
-    if (rows.length > 0 && rows.length <= MAX_DISTINCT_VALUES) {
-      values = rows.map((r) => String(r.v));
-    }
-  } catch {
-    values = null;
-  }
-
-  columnValueCache.set(cacheKey, values);
-  return values;
-}
-
-function getSchema() {
-  const tables = db
-    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
-    .all();
-
-  const schema = {};
-  for (const { name: table } of tables) {
-    const safeTable = `"${String(table).replaceAll('"', '""')}"`;
-    const columns = db.prepare(`PRAGMA table_info(${safeTable})`).all();
-    schema[table] = columns.map((c) => {
-      const col = { name: c.name, type: c.type };
-      if (String(c.type).toUpperCase().includes("TEXT") && !looksLikePII(table, c.name)) {
-        const values = sampleColumnValues(table, c.name);
-        if (values) col.sampleValues = values;
-      }
-      return col;
-    });
-  }
-  return schema;
+async function getSchema() {
+  return await sqlEngine.getSchema();
 }
 
 function formatSchema(schema) {
@@ -329,12 +265,10 @@ function parseSqlResponse(raw) {
 }
 
 // ── Query execution ───────────────────────────────────────────────────────────
+// Delegated to the active sqlEngine — same reasoning as getSchema() above.
 
-function runQuery(sql) {
-  const stmt = db.prepare(sql);
-  const rows = stmt.all();
-  const columns = rows.length > 0 ? Object.keys(rows[0]) : stmt.columns().map((c) => c.name);
-  return { columns, rows };
+async function runQuery(sql) {
+  return await sqlEngine.runQuery(sql);
 }
 
 // ── Pipeline (mirrors ../core/pipeline.py, including the SQL repair loop) ───
@@ -373,7 +307,7 @@ function buildMergedKnowledge() {
 }
 
 async function runPipeline(question) {
-  const schema = getSchema();
+  const schema = await getSchema();
   const knowledge = buildMergedKnowledge();
   // Selected once per request and reused for every repair attempt — the
   // relevant subset doesn't change mid-request, so there's no reason to
@@ -415,7 +349,7 @@ async function runPipeline(question) {
     // layer above before it's allowed to run.
     while (true) {
       try {
-        const { columns, rows } = runQuery(currentSql);
+        const { columns, rows } = await runQuery(currentSql);
         output.columns = columns;
         output.rows = rows;
         output.sql = currentSql;
@@ -460,9 +394,9 @@ app.get(/^(?!\/api).*/, (req, res) => {
   res.sendFile(path.join(WEB_DIST, "index.html"));
 });
 
-app.get("/api/schema", (req, res) => {
+app.get("/api/schema", async (req, res) => {
   try {
-    res.json(getSchema());
+    res.json(await getSchema());
   } catch (exc) {
     res.status(500).json({ error: String(exc.message || exc) });
   }
@@ -470,7 +404,8 @@ app.get("/api/schema", (req, res) => {
 
 app.get("/api/example-questions", async (req, res) => {
   try {
-    const questions = await generateExampleQuestions(getSchema());
+    const schema = await getSchema();
+    const questions = await generateExampleQuestions(schema);
     res.json(questions);
   } catch (exc) {
     res.status(500).json({ error: String(exc.message || exc) });
@@ -482,6 +417,8 @@ app.get("/api/config", (req, res) => {
     llmBaseUrl: LLM_BASE_URL,
     llmModel: LLM_MODEL,
     dbPath: path.basename(DB_PATH),
+    sqlEngine: process.env.SQL_ENGINE || "sqlite",
+    availableSqlEngines: listSqlEngines(),
     memoryEnabled: MEMORY.memoryEnabled,
     dbagentId: MEMORY.dbagentId,
     memoryBackend: process.env.MEMORY_BACKEND || "local",

--- a/app/sqlEngines/index.js
+++ b/app/sqlEngines/index.js
@@ -1,0 +1,65 @@
+// sqlEngines/index.js — registry of pluggable SQL query engines. Mirrors
+// memoryBackends/index.js's registry pattern exactly (same shape, same
+// reasoning) — see that file if this one is unclear. Adding a new engine
+// means writing sqlEngines/foo.js implementing getSchema()/runQuery(),
+// adding one entry below, and nothing in server.js needs to change.
+//
+// Every engine implements the same interface:
+//   getSchema() -> schema | Promise<schema>
+//     Same shape server.js's formatSchema()/buildUserPrompt() already
+//     expect: { [table]: [{ name, type, sampleValues? }] }.
+//   runQuery(sql) -> { columns, rows } | Promise<{ columns, rows }>
+//     `sql` is already validated (sqlSafety.js) and, on repair attempts,
+//     may be a retried statement — the engine just executes it.
+
+import path from "node:path";
+import { SQLiteEngine } from "./sqlite.js";
+import { MinioDuckDBEngine } from "./minioDuckdb.js";
+
+const REGISTRY = {
+  sqlite: {
+    description: "Node's built-in node:sqlite against a local file. The default.",
+    create: (env, { dataDir }) =>
+      new SQLiteEngine({
+        dbPath: env.DB_PATH || path.join(dataDir, "demo.db"),
+      }),
+  },
+  "minio-duckdb": {
+    description:
+      "Parquet files in MinIO (or any S3-compatible object store), queried through DuckDB's httpfs extension.",
+    create: (env) => {
+      if (!env.MINIO_ENDPOINT || !env.MINIO_BUCKET) {
+        throw new Error(
+          'SQL_ENGINE=minio-duckdb requires MINIO_ENDPOINT and MINIO_BUCKET to be set (see .env.example).'
+        );
+      }
+      return new MinioDuckDBEngine({
+        endpoint: env.MINIO_ENDPOINT,
+        bucket: env.MINIO_BUCKET,
+        prefix: env.MINIO_PREFIX || "",
+        accessKey: env.MINIO_ACCESS_KEY || "",
+        secretKey: env.MINIO_SECRET_KEY || "",
+        useSsl: (env.MINIO_USE_SSL || "false").toLowerCase() === "true",
+        region: env.MINIO_REGION || "us-east-1",
+      });
+    },
+  },
+};
+
+export function listSqlEngines() {
+  return Object.entries(REGISTRY).map(([name, { description }]) => ({ name, description }));
+}
+
+// `dataDir` is only used by the `sqlite` engine's default DB_PATH — kept as
+// an explicit param (rather than each engine computing its own
+// __dirname-relative path) so it's resolved the same way regardless of
+// engine, same reasoning as memoryBackends/index.js's createMemoryBackend.
+export function createSqlEngine(name, { env = process.env, dataDir } = {}) {
+  const key = (name || "sqlite").toLowerCase();
+  const entry = REGISTRY[key];
+  if (!entry) {
+    const available = Object.keys(REGISTRY).join(", ");
+    throw new Error(`Unknown SQL_ENGINE "${name}" — available engines: ${available}`);
+  }
+  return entry.create(env, { dataDir });
+}

--- a/app/sqlEngines/minioDuckdb.js
+++ b/app/sqlEngines/minioDuckdb.js
@@ -1,0 +1,124 @@
+// sqlEngines/minioDuckdb.js — queries Parquet files stored in MinIO (or any
+// other S3-compatible object store) via DuckDB's httpfs extension.
+//
+// MinIO holds no live database here, just Parquet objects under a bucket
+// prefix. DuckDB is the query engine that makes them queryable through
+// exactly the same getSchema()/runQuery() contract every other engine
+// implements — the LLM-facing pipeline in server.js never knows the data
+// lives in object storage rather than a real database.
+//
+// Convention: every `<prefix>/<table>.parquet` object directly under the
+// configured bucket/prefix becomes one logical table named <table>, exposed
+// as a DuckDB view over `read_parquet()`. That keeps the LLM's generated SQL
+// identical to what it would write against a real table ("SELECT * FROM
+// orders ...") — it never needs to know an S3 path or Parquet is involved.
+// Partitioned/multi-file-per-table datasets aren't handled by this Phase 1
+// (see app/README.md) — each table is exactly one Parquet object.
+
+import path from "node:path";
+import { DuckDBInstance } from "@duckdb/node-api";
+
+function escapeSqlLiteral(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+function quoteIdentifier(value) {
+  return `"${String(value).replaceAll('"', '""')}"`;
+}
+
+export class MinioDuckDBEngine {
+  constructor({ endpoint, bucket, prefix, accessKey, secretKey, useSsl, region }) {
+    this.bucket = bucket;
+    // Normalize so joining with the bucket/table name never produces a
+    // double slash regardless of how the env var was written.
+    this.prefix = (prefix || "").replace(/^\/+|\/+$/g, "");
+    this.tables = [];
+    // DuckDB extension install/load and view creation are async and can't
+    // happen in a constructor — every public method awaits this first.
+    // Cached as a single promise, same lazy-init pattern as
+    // memoryBackends/milvus.js's MilvusBackend, so concurrent calls before
+    // the first one resolves don't race to reconnect or re-create views.
+    this.ready = this.init({ endpoint, accessKey, secretKey, useSsl, region });
+  }
+
+  async init({ endpoint, accessKey, secretKey, useSsl, region }) {
+    const instance = await DuckDBInstance.create(); // in-memory — DuckDB itself
+    // stores nothing; every table is a view over Parquet objects in MinIO.
+    this.connection = await instance.connect();
+
+    await this.connection.run("INSTALL httpfs; LOAD httpfs;");
+    // DuckDB's S3 settings work against any S3-compatible endpoint, not
+    // just AWS — that's what makes MinIO usable here at all. s3_url_style
+    // 'path' is required for MinIO (and most self-hosted S3-compatible
+    // stores, e.g. bucket.example.com/key doesn't resolve for them); AWS S3
+    // itself defaults to virtual-hosted style, which is why this isn't
+    // DuckDB's own default.
+    await this.connection.run(`
+      SET s3_endpoint='${escapeSqlLiteral(endpoint)}';
+      SET s3_access_key_id='${escapeSqlLiteral(accessKey)}';
+      SET s3_secret_access_key='${escapeSqlLiteral(secretKey)}';
+      SET s3_url_style='path';
+      SET s3_use_ssl=${useSsl ? "true" : "false"};
+      SET s3_region='${escapeSqlLiteral(region)}';
+    `);
+
+    await this.createViews();
+  }
+
+  s3Path(objectName) {
+    const key = this.prefix ? `${this.prefix}/${objectName}` : objectName;
+    return `s3://${this.bucket}/${key}`;
+  }
+
+  // Discovers tables once at startup (mirrors MilvusBackend's one-time
+  // ensureCollection() call) rather than re-globbing on every request —
+  // cheap either way at Parquet-file counts this is meant for, but this
+  // keeps startup and query-time concerns separate. Adding/removing a
+  // Parquet object under the prefix requires a server restart to pick up;
+  // worth knowing before a live demo, not a hidden surprise.
+  async createViews() {
+    const globPattern = this.s3Path("*.parquet");
+    const reader = await this.connection.runAndReadAll(
+      `SELECT file FROM glob('${escapeSqlLiteral(globPattern)}')`
+    );
+    const files = reader.getRowObjectsJson().map((r) => String(r.file));
+
+    this.tables = [];
+    for (const filePath of files) {
+      const table = path.posix.basename(filePath, ".parquet");
+      await this.connection.run(
+        `CREATE OR REPLACE VIEW ${quoteIdentifier(table)} AS SELECT * FROM read_parquet('${escapeSqlLiteral(filePath)}')`
+      );
+      this.tables.push(table);
+    }
+
+    if (this.tables.length === 0) {
+      console.warn(
+        `[sqlEngines/minio-duckdb] no .parquet objects found under ${globPattern} — schema will be empty`
+      );
+    }
+  }
+
+  async getSchema() {
+    await this.ready;
+    const schema = {};
+    for (const table of this.tables) {
+      const reader = await this.connection.runAndReadAll(`DESCRIBE ${quoteIdentifier(table)}`);
+      schema[table] = reader.getRowObjectsJson().map((r) => ({
+        name: String(r.column_name),
+        type: String(r.column_type),
+      }));
+    }
+    return schema;
+  }
+
+  async runQuery(sql) {
+    await this.ready;
+    // No table-name rewriting needed here — the views created in
+    // createViews() mean the LLM's generated SQL (bare table names, exactly
+    // like it would write for any other engine) runs against this
+    // connection unmodified.
+    const reader = await this.connection.runAndReadAll(sql);
+    return { columns: reader.columnNames(), rows: reader.getRowObjectsJson() };
+  }
+}

--- a/app/sqlEngines/sqlite.js
+++ b/app/sqlEngines/sqlite.js
@@ -1,0 +1,105 @@
+// sqlEngines/sqlite.js — the default SQL engine: Node's built-in node:sqlite
+// module against a local file (data/demo.db by default).
+//
+// This is the same schema-introspection and query logic that used to live
+// directly in server.js, moved here unchanged so it can sit behind the same
+// pluggable interface every other engine implements (see sqlEngines/index.js)
+// — no functional change, just packaging.
+
+import { DatabaseSync } from "node:sqlite";
+
+// The LLM guesses literal column values ("status = 'Pending'" when the data
+// stores 'pending'), returning zero rows with no error — one of the most
+// common real-world text-to-SQL failures. Sampling distinct values for
+// low-cardinality TEXT columns and showing them in the schema fixes this
+// automatically, no config needed.
+const MAX_DISTINCT_VALUES = 10;
+// Skip columns whose name suggests personal data even if low-cardinality —
+// sampling exists to disambiguate enum-like columns, not to leak literal
+// customer data into every prompt. These patterns are unambiguous on their
+// own regardless of table.
+const PII_ALWAYS_PATTERNS = [
+  "email", "phone", "address", "ssn", "password", "secret", "token", "dob", "birth",
+];
+// "name" alone is ambiguous — customers.name is a person's name (PII),
+// products.name is not. Only treat *_name columns as PII when the table
+// itself looks like it holds people.
+const PERSON_TABLE_PATTERNS = [
+  "customer", "user", "person", "employee", "contact", "client", "patient", "student", "member",
+];
+
+function looksLikePII(table, columnName) {
+  const lowerCol = columnName.toLowerCase();
+  if (PII_ALWAYS_PATTERNS.some((p) => lowerCol.includes(p))) return true;
+  if (lowerCol.includes("name")) {
+    const lowerTable = table.toLowerCase();
+    return PERSON_TABLE_PATTERNS.some((p) => lowerTable.includes(p));
+  }
+  return false;
+}
+
+export class SQLiteEngine {
+  constructor({ dbPath }) {
+    this.db = new DatabaseSync(dbPath, { readOnly: false });
+    // Cached for the process lifetime rather than re-sampled every request
+    // — the schema itself is read fresh each time (cheap PRAGMA calls), but
+    // sampling adds a real query per eligible column, and the underlying
+    // data doesn't change from a user's perspective the way a knowledge.json
+    // edit would. A server restart clears it.
+    this.columnValueCache = new Map();
+  }
+
+  sampleColumnValues(table, column) {
+    const cacheKey = `${table}.${column}`;
+    if (this.columnValueCache.has(cacheKey)) return this.columnValueCache.get(cacheKey);
+
+    let values = null;
+    try {
+      const safeTable = `"${table.replaceAll('"', '""')}"`;
+      const safeColumn = `"${column.replaceAll('"', '""')}"`;
+      const rows = this.db
+        .prepare(
+          `SELECT DISTINCT ${safeColumn} AS v FROM ${safeTable} WHERE ${safeColumn} IS NOT NULL LIMIT ${MAX_DISTINCT_VALUES + 1}`
+        )
+        .all();
+      // Hitting the +1 limit means the column is higher-cardinality than
+      // "enum-like" — skip it rather than show a truncated, misleading list.
+      if (rows.length > 0 && rows.length <= MAX_DISTINCT_VALUES) {
+        values = rows.map((r) => String(r.v));
+      }
+    } catch {
+      values = null;
+    }
+
+    this.columnValueCache.set(cacheKey, values);
+    return values;
+  }
+
+  getSchema() {
+    const tables = this.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+      .all();
+
+    const schema = {};
+    for (const { name: table } of tables) {
+      const safeTable = `"${String(table).replaceAll('"', '""')}"`;
+      const columns = this.db.prepare(`PRAGMA table_info(${safeTable})`).all();
+      schema[table] = columns.map((c) => {
+        const col = { name: c.name, type: c.type };
+        if (String(c.type).toUpperCase().includes("TEXT") && !looksLikePII(table, c.name)) {
+          const values = this.sampleColumnValues(table, c.name);
+          if (values) col.sampleValues = values;
+        }
+        return col;
+      });
+    }
+    return schema;
+  }
+
+  runQuery(sql) {
+    const stmt = this.db.prepare(sql);
+    const rows = stmt.all();
+    const columns = rows.length > 0 ? Object.keys(rows[0]) : stmt.columns().map((c) => c.name);
+    return { columns, rows };
+  }
+}


### PR DESCRIPTION
**Stacked on #48** — base branch is `memory-milvus-backend`, not `main`, since this builds directly on that branch's memory-backend registry (both server.js changes are adjacent). Merge #48 first; this diff will shrink to just the SQL-engine work once that lands.

## Summary
- Extracts SQL execution (previously a hardcoded `node:sqlite` connection directly in `server.js`) into `sqlEngines/`, the same registry pattern as `memoryBackends/`
- `sqlEngines/sqlite.js` carries the existing PII-aware schema/sampling logic over unchanged — verified behavior-equivalent (7/7 seed benchmarks still pass). `server.js`'s `getSchema()`/`runQuery()` are now thin delegators, selected via `SQL_ENGINE`, defaulting to `sqlite` so the zero-config path is unaffected
- Adds `minio-duckdb`: queries Parquet objects in MinIO (or any S3-compatible store) through DuckDB's `httpfs` extension. Each `<table>.parquet` object becomes a DuckDB view at startup, so the LLM's generated SQL never needs to know an S3 path or Parquet is involved — it just sees table names like any other engine. `sqlSafety.js`'s existing read-only validator gates it identically regardless of active engine (reused, not forked)
- `scripts/minio-demo-compose.yml` + `scripts/seed-minio-demo.js` give a one-command local demo, seeded from the same customers/products/orders domain as the SQLite default (exported via DuckDB's own `sqlite` extension — no second dataset to maintain)

## Test plan
- [x] `node --check` on all changed/new files
- [x] `npm run benchmark` — 7/7 seed cases pass against local Ollama on the default `sqlite` engine (zero MinIO config set)
- [x] **Verified against a real local MinIO instance (Docker), not mocked**: schema introspection, a multi-table join, and the repair loop's error-catching path all confirmed working end to end
- [x] Verified no AWS bucket names/ARNs/tokens present in the diff

## Known caveats (documented in `app/README.md`)
- DuckDB `BIGINT` columns (`COUNT`/integer aggregates) serialize as JSON strings, not native numbers — a raw JS `bigint` isn't valid input to `JSON.stringify`. `DOUBLE` columns are unaffected
- Partitioned/multi-file-per-table datasets aren't supported yet — each table is exactly one Parquet object. Iceberg support (DuckDB has an `iceberg` extension; MinIO's AIStor product supports Iceberg-backed tables) is a natural next step

🤖 Generated with [Claude Code](https://claude.com/claude-code)