### PR TITLE
Surface which SQL engine/location is actually serving each request

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -307,6 +307,14 @@ function buildMergedKnowledge() {
 }
 
 async function runPipeline(question) {
+  // Cheap, always-on visibility into which engine/location actually served
+  // this request — added after a live real-S3 test made clear there was
+  // otherwise no way to confirm from the server logs whether a request hit
+  // local SQLite or a remote S3/MinIO bucket without separately hitting
+  // /api/config.
+  const engineInfo = sqlEngine.describe();
+  console.log(`[ask] "${question}" -> ${engineInfo.type} (${engineInfo.location})`);
+
   const schema = await getSchema();
   const knowledge = buildMergedKnowledge();
   // Selected once per request and reused for every repair attempt — the
@@ -418,6 +426,7 @@ app.get("/api/config", (req, res) => {
     llmModel: LLM_MODEL,
     dbPath: path.basename(DB_PATH),
     sqlEngine: process.env.SQL_ENGINE || "sqlite",
+    sqlEngineInfo: sqlEngine.describe(),
     availableSqlEngines: listSqlEngines(),
     memoryEnabled: MEMORY.memoryEnabled,
     dbagentId: MEMORY.dbagentId,
@@ -542,7 +551,11 @@ app.post("/api/memories/invalidate", async (req, res) => {
 });
 
 app.listen(PORT, () => {
+  const engineInfo = sqlEngine.describe();
   console.log(`DB Agent (Node) running at http://localhost:${PORT}`);
-  console.log(`DB: ${DB_PATH}`);
+  console.log(
+    `SQL engine: ${engineInfo.type} -> ${engineInfo.location}` +
+      (engineInfo.endpoint ? ` (endpoint: ${engineInfo.endpoint})` : "")
+  );
   console.log(`LLM: ${LLM_BASE_URL} (${LLM_MODEL})`);
 });

--- a/app/sqlEngines/minioDuckdb.js
+++ b/app/sqlEngines/minioDuckdb.js
@@ -28,6 +28,7 @@ function quoteIdentifier(value) {
 
 export class MinioDuckDBEngine {
   constructor({ endpoint, bucket, prefix, accessKey, secretKey, useSsl, region }) {
+    this.endpoint = endpoint;
     this.bucket = bucket;
     // Normalize so joining with the bucket/table name never produces a
     // double slash regardless of how the env var was written.
@@ -120,5 +121,14 @@ export class MinioDuckDBEngine {
     // connection unmodified.
     const reader = await this.connection.runAndReadAll(sql);
     return { columns: reader.columnNames(), rows: reader.getRowObjectsJson() };
+  }
+
+  // Same purpose as SQLiteEngine.describe() — lets server.js's startup log
+  // and /api/config say where a query is actually going, rather than the
+  // old always-shows-the-sqlite-default behavior. `endpoint` is included
+  // since the same engine serves both MinIO and real AWS S3 (and any other
+  // S3-compatible store) — the bucket path alone doesn't tell you which.
+  describe() {
+    return { type: "minio-duckdb", location: this.s3Path(""), endpoint: this.endpoint };
   }
 }

--- a/app/sqlEngines/sqlite.js
+++ b/app/sqlEngines/sqlite.js
@@ -40,6 +40,7 @@ function looksLikePII(table, columnName) {
 
 export class SQLiteEngine {
   constructor({ dbPath }) {
+    this.dbPath = dbPath;
     this.db = new DatabaseSync(dbPath, { readOnly: false });
     // Cached for the process lifetime rather than re-sampled every request
     // — the schema itself is read fresh each time (cheap PRAGMA calls), but
@@ -101,5 +102,14 @@ export class SQLiteEngine {
     const rows = stmt.all();
     const columns = rows.length > 0 ? Object.keys(rows[0]) : stmt.columns().map((c) => c.name);
     return { columns, rows };
+  }
+
+  // Surfaced in server.js's startup log and /api/config so it's obvious at
+  // a glance (and from the UI) which physical location a query is actually
+  // hitting — added after a live test made clear the old startup log line
+  // ("DB: <path>") stayed hardcoded to the sqlite default even when a
+  // different engine was active, which was actively misleading.
+  describe() {
+    return { type: "sqlite", location: this.dbPath };
   }
 }

--- a/app/web/src/components/Sidebar.tsx
+++ b/app/web/src/components/Sidebar.tsx
@@ -5,8 +5,9 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Separator } from "@/components/ui/separator";
+import { getSqlEngineIcon } from "@/components/SqlEngineIcon";
 import type { AppConfig, Conversation, Schema } from "@/lib/types";
-import { Database, MessageSquare, Plus, Server } from "lucide-react";
+import { MessageSquare, Plus, Server } from "lucide-react";
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -92,12 +93,24 @@ export function Sidebar({
             </div>
 
             <FieldLabel>Database</FieldLabel>
-            <div className="flex items-center gap-2 text-xs">
-              <Database className="size-3.5 text-muted-foreground" />
-              <code className="rounded bg-muted px-1.5 py-0.5">
-                {config?.dbPath ?? "…"}
-              </code>
-            </div>
+            {(() => {
+              const engineInfo = config?.sqlEngineInfo;
+              const { icon, label } = getSqlEngineIcon(engineInfo?.type);
+              return (
+                <div className="flex items-center gap-2 text-xs" title={label}>
+                  {icon}
+                  <code className="rounded bg-muted px-1.5 py-0.5 break-all">
+                    {engineInfo?.location ?? config?.dbPath ?? "…"}
+                  </code>
+                </div>
+              );
+            })()}
+            {config?.sqlEngineInfo && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                {getSqlEngineIcon(config.sqlEngineInfo.type).label}
+                {config.sqlEngineInfo.endpoint ? ` · ${config.sqlEngineInfo.endpoint}` : ""}
+              </p>
+            )}
 
             <FieldLabel>Schema</FieldLabel>
             {schema ? (

--- a/app/web/src/components/SqlEngineIcon.tsx
+++ b/app/web/src/components/SqlEngineIcon.tsx
@@ -1,0 +1,43 @@
+// SqlEngineIcon.tsx — maps a SQL engine's `type` (from sqlEngineInfo, see
+// server.js's /api/config) to a representative icon + short label, used in
+// the sidebar's "Database" field.
+//
+// These are generic lucide-react icons (already a dependency), not official
+// brand logos — bundling real AWS/Databricks/etc. trademarked assets needs
+// a legitimately-sourced logo file, which this repo doesn't have. Swapping
+// in a real logo later is a one-line change per entry once you have one:
+// replace the `icon` value with an <img src="/logos/whatever.svg" />,
+// nothing else needs to change.
+//
+// Extensible on purpose: a future engine (e.g. a Databricks Lakebase
+// backend) just adds one entry here, keyed by whatever `type` string its
+// sqlEngines/*.js file returns from describe().
+
+import { Cloud, Database, HardDrive } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SqlEngineIconEntry {
+  icon: ReactNode;
+  label: string;
+}
+
+const REGISTRY: Record<string, SqlEngineIconEntry> = {
+  sqlite: {
+    icon: <HardDrive className="size-3.5 text-muted-foreground" />,
+    label: "Local file",
+  },
+  "minio-duckdb": {
+    icon: <Cloud className="size-3.5 text-[var(--brand-azure)]" />,
+    label: "S3-compatible object storage",
+  },
+};
+
+const FALLBACK: SqlEngineIconEntry = {
+  icon: <Database className="size-3.5 text-muted-foreground" />,
+  label: "Database",
+};
+
+export function getSqlEngineIcon(type: string | undefined): SqlEngineIconEntry {
+  if (!type) return FALLBACK;
+  return REGISTRY[type] ?? FALLBACK;
+}

--- a/app/web/src/lib/types.ts
+++ b/app/web/src/lib/types.ts
@@ -23,10 +23,18 @@ export interface PipelineOutput {
   repairAttempts: number;
 }
 
+export interface SqlEngineInfo {
+  type: string;
+  location: string;
+  endpoint?: string;
+}
+
 export interface AppConfig {
   llmBaseUrl: string;
   llmModel: string;
   dbPath: string;
+  sqlEngine: string;
+  sqlEngineInfo: SqlEngineInfo;
   memoryEnabled: boolean;
   dbagentId: string;
   memoryBackend: string;


### PR DESCRIPTION
## Summary
- Fixes a real bug found while live-testing against real S3: the startup log's `DB: <path>` line stayed hardcoded to the SQLite default even when `SQL_ENGINE=minio-duckdb` was active — there was no way to confirm from the server logs (or without a separate `/api/config` call) whether a request was actually hitting local SQLite or a remote S3/MinIO bucket
- Adds `describe()` to both `sqlEngines/*.js` engines (`{ type, location, endpoint? }`), used for: a corrected startup log, a per-request log line on every `/api/ask` (`[ask] "<question>" -> <engine> (<location>)`), and a new `sqlEngineInfo` field on `/api/config`
- Sidebar's "Database" field now shows the real live location (an `s3://` path or the SQLite file path) instead of always showing `dbPath`, with a representative icon per engine type

## Note on icons
Uses generic `lucide-react` icons (already a dependency), not official AWS/Databricks logos — bundling real trademarked brand assets needs a legitimately-sourced file this repo doesn't have. The registry (`SqlEngineIcon.tsx`) is keyed by engine `type` so swapping in a real logo later, or adding an icon for a future engine (e.g. a Databricks Lakebase backend), is a one-entry change.

## Test plan
- [x] `node --check` on all changed backend files, `tsc -b --noEmit` clean, `npm run build` succeeds
- [x] `npm run benchmark` — 7/7 seed cases pass, per-request log line confirmed showing in output
- [x] Manually verified startup log + `/api/config` + Sidebar UI against both `sqlite` and `minio-duckdb` (against a real local MinIO instance)
- [x] Verified no AWS bucket names/ARNs/tokens present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)