### PR TITLE
Add a Postgres/Lakebase SQL engine and timestamped request logging

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -25,6 +25,24 @@ LLM_MODEL=qwen2.5-coder:7b
 # MINIO_USE_SSL=false
 # MINIO_REGION=us-east-1              # arbitrary for MinIO, still required for SigV4
 
+# SQL_ENGINE=postgres — any standard Postgres database, covers Databricks
+# Lakebase directly (same wire protocol, no Lakebase-specific code needed).
+# Either a full connection string (DB_URL, works with Lakebase's own
+# "postgresql+psycopg://..." connection string as-is — the +psycopg suffix
+# is a Python-driver convention that node-postgres's parser just ignores):
+# SQL_ENGINE=postgres
+# DB_URL=postgresql://user:password@host:5432/dbname?sslmode=require
+# ...or individual fields instead of DB_URL:
+# PG_HOST=host
+# PG_PORT=5432
+# PG_DATABASE=dbname
+# PG_USER=user
+# PG_PASSWORD=password
+# PG_SSL=default   # "default" = TLS with relaxed cert validation (works against
+#                  # most managed-Postgres CA chains out of the box), "strict" =
+#                  # full certificate verification, "false" = no TLS (local only)
+# PG_SCHEMA=public
+
 # ── Cross-platform contextual memory ────────────────────────────────────────
 # Unique per running instance — tags writes, excludes self on reads.
 DBAGENT_ID=local

--- a/app/README.md
+++ b/app/README.md
@@ -7,12 +7,13 @@ model and widget styling. See the root `README.md` for background on the
 project.
 
 Scope is intentionally narrower than the Python app in one respect: a
-single LLM (no model failover chain, no Databricks-native SQL backend). It
-does carry over the SQL repair-on-failure loop and the cross-platform
-contextual memory feature. The SQL layer itself is pluggable
-(`sqlEngines/`, same registry pattern as the memory backends): `sqlite`
-(default, a local file) or `minio-duckdb` (Parquet objects in MinIO/any
-S3-compatible store, via DuckDB) — see Notes below.
+single LLM (no model failover chain). It does carry over the SQL
+repair-on-failure loop and the cross-platform contextual memory feature.
+The SQL layer itself is pluggable (`sqlEngines/`, same registry pattern as
+the memory backends): `sqlite` (default, a local file), `minio-duckdb`
+(Parquet objects in MinIO/any S3-compatible store, via DuckDB), or
+`postgres` (any standard Postgres database — covers Databricks Lakebase
+directly) — see Notes below.
 
 Two parts:
 - `server.js` / `memory.js` — Express API (`/api/schema`, `/api/config`,
@@ -132,6 +133,30 @@ documented-supported) — the deployment shape is the same generic
     demo and compare. MinIO console at `http://localhost:9001`
     (`minioadmin`/`minioadmin`) if you want to browse the uploaded Parquet
     objects visually mid-demo.
+  - `postgres` — any standard Postgres database, via [`pg`](https://node-postgres.com)
+    (node-postgres). Covers **Databricks Lakebase directly** — Lakebase
+    speaks the standard Postgres wire protocol, so this engine has no
+    Lakebase-specific code, just connection details pointed at it. **Verified
+    end-to-end against a real Lakebase instance** (a Kaggle Olist e-commerce
+    dataset, 12 tables) — schema introspection and a live query both
+    confirmed working, local Ollama generating the SQL.
+
+    Either a full connection string (`DB_URL`) or individual
+    `PG_HOST`/`PG_PORT`/`PG_DATABASE`/`PG_USER`/`PG_PASSWORD` fields (see
+    `.env.example`). Lakebase's own connection-details panel gives you a
+    `postgresql+psycopg://...` string (a Python-driver convention) — that
+    works as-is for `DB_URL`, node-postgres's connection-string parser
+    ignores the `+psycopg` suffix. `PG_SSL` defaults to TLS with relaxed
+    certificate validation (works against most managed-Postgres CA chains
+    out of the box); set `PG_SSL=strict` for full verification or
+    `PG_SSL=false` to disable TLS (local Postgres only, never for Lakebase).
+
+    No PII-aware sample-value mining in this first pass (same scope decision
+    as `minio-duckdb`) — every column is exposed as name+type only. If your
+    Lakebase connection uses a short-lived Databricks OAuth token as the
+    password (common), expect to refresh `DB_URL` periodically — an expired
+    token surfaces as a normal Postgres auth error in the `/api/ask`
+    response, not a crash.
 - **Optional knowledge file** (`knowledge.js`, `knowledge.json`): the schema
   alone (table/column names + types) doesn't carry business terminology,
   ambiguous-column meaning, or house rules — this is where those go. Copy
@@ -226,5 +251,13 @@ documented-supported) — the deployment shape is the same generic
   `.github/workflows/app-benchmark.yml`, gated on the
   `LLM_BASE_URL`/`LLM_API_KEY` repo secrets being configured (skipped, not
   failed, otherwise). Only a **seed** case failing fails the workflow.
+- **Timestamped request logging** (`logger.js`): every server log line is
+  prefixed with an ISO timestamp, and `/api/ask` logs a line at each stage
+  of the pipeline — request start (with which SQL engine/location is
+  serving it), SQL generated, each repair attempt, and done (with row count
+  and repair-attempt count). No duration/timing math is done by the app
+  itself on purpose — diff the timestamps yourself to see where time is
+  actually going (LLM call vs. query execution vs. repairs), since that's
+  more trustworthy than a single self-reported number would be.
 - No streaming, no auth — this is a UI comparison prototype, not a
   production alternative to the Streamlit app.

--- a/app/logger.js
+++ b/app/logger.js
@@ -1,0 +1,18 @@
+// logger.js — every log line gets a timestamp prefix, so wall-clock timing
+// (e.g. "how long did text-to-SQL take end to end?") can be read straight
+// off the log rather than requiring the app to compute and report
+// durations itself. Deliberately just a timestamp prefix, not a logging
+// framework — this app has one process, one log stream (stdout), no need
+// for levels/transports/structured fields beyond what's already useful.
+
+function timestamp() {
+  return new Date().toISOString();
+}
+
+export function log(message) {
+  console.log(`[${timestamp()}] ${message}`);
+}
+
+export function warn(message) {
+  console.warn(`[${timestamp()}] ${message}`);
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -13,7 +13,8 @@
         "@zilliz/milvus2-sdk-node": "^3.0.3",
         "dotenv": "^16.4.5",
         "express": "^4.21.0",
-        "openai": "^4.67.0"
+        "openai": "^4.67.0",
+        "pg": "^8.22.0"
       },
       "engines": {
         "node": ">=22.5.0"
@@ -2042,6 +2043,134 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -2326,6 +2455,15 @@
       "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.7.0.tgz",
       "integrity": "sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==",
       "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -2661,6 +2799,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,7 @@
     "@zilliz/milvus2-sdk-node": "^3.0.3",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
-    "openai": "^4.67.0"
+    "openai": "^4.67.0",
+    "pg": "^8.22.0"
   }
 }

--- a/app/server.js
+++ b/app/server.js
@@ -18,6 +18,7 @@ import { createSqlEngine, listSqlEngines } from "./sqlEngines/index.js";
 import { formatKnowledge, loadKnowledge, selectRelevantKnowledge } from "./knowledge.js";
 import { validateSql } from "./sqlSafety.js";
 import { benchmarkStore } from "./benchmarks.js";
+import { log, warn } from "./logger.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -242,7 +243,7 @@ Respond with ONLY a JSON array of 5 strings, no other text.`;
     }
     questions = parsed.slice(0, 5);
   } catch (exc) {
-    console.warn(`[examples] generation failed, using heuristic fallback: ${exc.message || exc}`);
+    warn(`[examples] generation failed, using heuristic fallback: ${exc.message || exc}`);
     questions = heuristicExampleQuestions(schema);
   }
 
@@ -307,21 +308,31 @@ function buildMergedKnowledge() {
 }
 
 async function runPipeline(question) {
-  // Cheap, always-on visibility into which engine/location actually served
-  // this request — added after a live real-S3 test made clear there was
-  // otherwise no way to confirm from the server logs whether a request hit
-  // local SQLite or a remote S3/MinIO bucket without separately hitting
-  // /api/config.
+  // Every line here is timestamped (see logger.js) specifically so
+  // end-to-end text-to-SQL latency — and where it's actually going, LLM
+  // call vs. query execution vs. repair loop — can be read straight off
+  // the log by diffing timestamps, with no timing/duration math done by
+  // the app itself.
   const engineInfo = sqlEngine.describe();
-  console.log(`[ask] "${question}" -> ${engineInfo.type} (${engineInfo.location})`);
+  log(`[ask] start "${question}" -> ${engineInfo.type} (${engineInfo.location})`);
 
-  const schema = await getSchema();
-  const knowledge = buildMergedKnowledge();
-  // Selected once per request and reused for every repair attempt — the
-  // relevant subset doesn't change mid-request, so there's no reason to
-  // re-embed on every repair loop iteration.
-  const selectedKnowledge = await selectRelevantKnowledge(knowledge, question, embeddingClient, MEMORY.embeddingModel);
-  const knowledgeText = formatKnowledge(selectedKnowledge);
+  let schema, knowledgeText;
+  try {
+    schema = await getSchema();
+    const knowledge = buildMergedKnowledge();
+    // Selected once per request and reused for every repair attempt — the
+    // relevant subset doesn't change mid-request, so there's no reason to
+    // re-embed on every repair loop iteration.
+    const selectedKnowledge = await selectRelevantKnowledge(knowledge, question, embeddingClient, MEMORY.embeddingModel);
+    knowledgeText = formatKnowledge(selectedKnowledge);
+  } catch (exc) {
+    // Rethrown as-is (same behavior as before this log line was added) —
+    // just makes sure a failure this early still gets a "done" timestamp
+    // instead of silently having no closing log line for the request.
+    log(`[ask] done (error before SQL generation: ${String(exc.message || exc)})`);
+    throw exc;
+  }
+
   const output = {
     question,
     schemaContext: formatSchema(schema),
@@ -339,13 +350,18 @@ async function runPipeline(question) {
     const parsed = parseSqlResponse(raw);
     output.sql = parsed.sql;
     output.explanation = parsed.explanation;
+    log(`[ask] sql generated: ${parsed.sql || "(empty)"}`);
 
     const validation = validateSql(parsed.sql);
     output.validation = validation;
-    if (!validation.isSafe) return output;
+    if (!validation.isSafe) {
+      log(`[ask] done (rejected by safety validation: ${validation.reason})`);
+      return output;
+    }
 
     if (!parsed.sql) {
       output.validation = { isSafe: false, reason: "The LLM could not generate a query for this question." };
+      log(`[ask] done (no SQL generated)`);
       return output;
     }
 
@@ -361,10 +377,12 @@ async function runPipeline(question) {
         output.columns = columns;
         output.rows = rows;
         output.sql = currentSql;
+        log(`[ask] done, ${rows.length} row(s) returned (${attempts} repair attempt(s))`);
         break;
       } catch (dbErr) {
         if (attempts >= MAX_REPAIR_ATTEMPTS) throw dbErr;
         attempts += 1;
+        log(`[ask] query failed, starting repair attempt ${attempts}: ${String(dbErr.message || dbErr)}`);
 
         const repairRaw = await callLlm(
           SYSTEM_PROMPT,
@@ -375,9 +393,11 @@ async function runPipeline(question) {
         output.sql = repaired.sql;
         output.explanation = repaired.explanation;
         output.repairAttempts = attempts;
+        log(`[ask] repair attempt ${attempts} sql: ${repaired.sql || "(empty)"}`);
 
         if (!repairValidation.isSafe) {
           output.validation = repairValidation;
+          log(`[ask] done (repair rejected by safety validation: ${repairValidation.reason})`);
           return output;
         }
         currentSql = repaired.sql;
@@ -385,6 +405,7 @@ async function runPipeline(question) {
     }
   } catch (exc) {
     output.error = String(exc.message || exc);
+    log(`[ask] done (error: ${output.error})`);
   }
 
   return output;
@@ -450,7 +471,7 @@ app.post("/api/ask", async (req, res) => {
     // Fire-and-forget: memory is cross-platform context, not a critical path
     // — never block the response on a second LLM call + store write.
     void writeMemory(llm, output, MEMORY).catch((err) => {
-      console.warn(`[memory] write failed: ${err?.message || err}`);
+      warn(`[memory] write failed: ${err?.message || err}`);
     });
   } catch (exc) {
     res.status(500).json({ error: String(exc.message || exc) });
@@ -495,7 +516,7 @@ app.post("/api/feedback", (req, res) => {
     // Fire-and-forget, same reasoning as the writeMemory call in /api/ask.
     if (rating === "down") {
       void invalidateFollowup(question, MEMORY).catch((err) => {
-        console.warn(`[memory] invalidate failed: ${err?.message || err}`);
+        warn(`[memory] invalidate failed: ${err?.message || err}`);
       });
     }
   } catch (exc) {
@@ -552,10 +573,10 @@ app.post("/api/memories/invalidate", async (req, res) => {
 
 app.listen(PORT, () => {
   const engineInfo = sqlEngine.describe();
-  console.log(`DB Agent (Node) running at http://localhost:${PORT}`);
-  console.log(
+  log(`DB Agent (Node) running at http://localhost:${PORT}`);
+  log(
     `SQL engine: ${engineInfo.type} -> ${engineInfo.location}` +
       (engineInfo.endpoint ? ` (endpoint: ${engineInfo.endpoint})` : "")
   );
-  console.log(`LLM: ${LLM_BASE_URL} (${LLM_MODEL})`);
+  log(`LLM: ${LLM_BASE_URL} (${LLM_MODEL})`);
 });

--- a/app/sqlEngines/index.js
+++ b/app/sqlEngines/index.js
@@ -15,6 +15,8 @@
 import path from "node:path";
 import { SQLiteEngine } from "./sqlite.js";
 import { MinioDuckDBEngine } from "./minioDuckdb.js";
+import { PostgresEngine } from "./postgres.js";
+
 
 const REGISTRY = {
   sqlite: {
@@ -41,6 +43,28 @@ const REGISTRY = {
         secretKey: env.MINIO_SECRET_KEY || "",
         useSsl: (env.MINIO_USE_SSL || "false").toLowerCase() === "true",
         region: env.MINIO_REGION || "us-east-1",
+      });
+    },
+  },
+  postgres: {
+    description:
+      "Any standard Postgres database (covers Databricks Lakebase directly — same wire protocol).",
+    create: (env) => {
+      if (!env.DB_URL && !(env.PG_HOST && env.PG_DATABASE)) {
+        throw new Error(
+          "SQL_ENGINE=postgres requires either DB_URL (a full postgres:// connection string) " +
+            "or PG_HOST + PG_DATABASE (see .env.example)."
+        );
+      }
+      return new PostgresEngine({
+        connectionString: env.DB_URL || undefined,
+        host: env.PG_HOST,
+        port: env.PG_PORT || "5432",
+        database: env.PG_DATABASE,
+        user: env.PG_USER,
+        password: env.PG_PASSWORD,
+        ssl: env.PG_SSL || "default",
+        schema: env.PG_SCHEMA || "public",
       });
     },
   },

--- a/app/sqlEngines/postgres.js
+++ b/app/sqlEngines/postgres.js
@@ -1,0 +1,92 @@
+// sqlEngines/postgres.js — any standard Postgres-wire-protocol database,
+// via the `pg` (node-postgres) driver. Covers Databricks Lakebase (managed
+// Postgres) directly — Lakebase speaks the standard Postgres protocol, so
+// this engine needs no Lakebase-specific code, just a host/port/database/
+// user/password/sslmode pointed at it. Get those from Lakebase's own
+// "Connection details" panel; this engine doesn't assume any particular
+// auth method (password vs. a Databricks OAuth token as the password both
+// work, since from this driver's perspective it's just a password).
+//
+// Schema is read fresh per request (information_schema.columns), same
+// reasoning as sqlEngines/sqlite.js: cheap, and a table added to the
+// database should show up without a server restart. No PII-aware sample
+// value mining in this first pass (same scope decision as
+// sqlEngines/minioDuckdb.js) — every column is exposed as name+type only.
+
+import pg from "pg";
+
+const { Pool } = pg;
+
+function sslOption(ssl) {
+  // Lakebase (and most managed Postgres) requires TLS; rejectUnauthorized:
+  // false is the pragmatic default for managed-service CA chains that
+  // aren't in Node's default trust store — set PG_SSL=strict to require
+  // full verification instead.
+  if (ssl === "strict") return true;
+  if (ssl === "false") return false;
+  return { rejectUnauthorized: false };
+}
+
+// Strips user:password out of a connection string for display/logging —
+// same "never leak credentials" reasoning as everywhere else this project
+// touches secrets. Falls back to a redacted placeholder if the string
+// doesn't parse as a URL for any reason, rather than risking a leak.
+function redactConnectionString(connectionString) {
+  try {
+    const url = new URL(connectionString);
+    url.username = "";
+    url.password = "";
+    return url.toString();
+  } catch {
+    return "postgres://<unparsed-connection-string>";
+  }
+}
+
+export class PostgresEngine {
+  constructor({ connectionString, host, port, database, user, password, ssl, schema }) {
+    this.schemaName = schema || "public";
+
+    if (connectionString) {
+      this.displayLocation = redactConnectionString(connectionString);
+      this.pool = new Pool({ connectionString, ssl: sslOption(ssl) });
+    } else {
+      this.displayLocation = `postgres://${host}:${port}/${database}?schema=${this.schemaName}`;
+      this.pool = new Pool({
+        host,
+        port: Number(port) || 5432,
+        database,
+        user,
+        password,
+        ssl: sslOption(ssl),
+      });
+    }
+  }
+
+  async getSchema() {
+    const { rows } = await this.pool.query(
+      `SELECT table_name, column_name, data_type
+       FROM information_schema.columns
+       WHERE table_schema = $1
+       ORDER BY table_name, ordinal_position`,
+      [this.schemaName]
+    );
+
+    const schema = {};
+    for (const row of rows) {
+      const table = row.table_name;
+      if (!schema[table]) schema[table] = [];
+      schema[table].push({ name: row.column_name, type: row.data_type });
+    }
+    return schema;
+  }
+
+  async runQuery(sql) {
+    const result = await this.pool.query(sql);
+    const columns = result.fields.map((f) => f.name);
+    return { columns, rows: result.rows };
+  }
+
+  describe() {
+    return { type: "postgres", location: this.displayLocation };
+  }
+}

--- a/app/web/src/components/SqlEngineIcon.tsx
+++ b/app/web/src/components/SqlEngineIcon.tsx
@@ -30,6 +30,10 @@ const REGISTRY: Record<string, SqlEngineIconEntry> = {
     icon: <Cloud className="size-3.5 text-[var(--brand-azure)]" />,
     label: "S3-compatible object storage",
   },
+  postgres: {
+    icon: <Database className="size-3.5 text-[var(--brand-orange)]" />,
+    label: "Postgres (or Databricks Lakebase)",
+  },
 };
 
 const FALLBACK: SqlEngineIconEntry = {


### PR DESCRIPTION
## Summary
- Adds `sqlEngines/postgres.js` (via `node-postgres`): any standard Postgres database, which covers **Databricks Lakebase directly** since it speaks the same wire protocol — no Lakebase-specific code, just connection details. Accepts either a full `DB_URL` connection string or individual `PG_*` fields
- Lakebase's own connection-details panel gives a `postgresql+psycopg://...` string (a Python-driver convention) — verified `node-postgres`'s parser tolerates the `+psycopg` suffix fine rather than assuming it would
- Adds `logger.js`: every server log line gets an ISO timestamp prefix, and `/api/ask` now logs at each pipeline stage (request start with which engine/location is serving it, SQL generated, each repair attempt, done with row/repair-attempt counts) — end-to-end text-to-SQL latency, and where it's actually going, can be read straight off the log by diffing timestamps, with no timing math done by the app itself
- Fixes a real gap found while testing against an expired Lakebase OAuth token: schema/knowledge-selection failures happened *before* `runPipeline`'s try block, so they never got a closing "done" log line — now every request logs both a start and a done line regardless of where it fails

## Test plan
- [x] `node --check` on all changed/new backend files, `tsc -b --noEmit` clean
- [x] `npm run benchmark` — 7/7 seed cases pass against local Ollama on the default `sqlite` engine, with clean timestamped logs throughout
- [x] **Verified end-to-end against a real Lakebase instance** (a Kaggle Olist e-commerce dataset, 12 tables): schema introspection and a live query both confirmed working, local Ollama generating the SQL, memory write confirmed landing in a real S3 Vectors index
- [x] Verified no credentials/tokens/bucket names present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)