### PR TITLE
Surface connection errors predictably instead of a silently broken UI

### DIFF
--- a/app/logger.js
+++ b/app/logger.js
@@ -16,3 +16,17 @@ export function log(message) {
 export function warn(message) {
   console.warn(`[${timestamp()}] ${message}`);
 }
+
+// Node's `pg` (and other libraries doing multi-attempt connects, e.g.
+// trying both IPv4 and IPv6) throws an AggregateError when every attempt
+// fails — its own .message is empty/unhelpful ("AggregateError"), with the
+// actual reason (ECONNREFUSED, auth failure, etc.) buried in .errors[].
+// Found this the hard way: a deliberately-unreachable Postgres host
+// surfaced as just "AggregateError" in the UI, which is exactly the kind
+// of unpredictable, unreadable error state that shouldn't reach a user.
+export function describeError(exc) {
+  if (exc?.errors?.length) {
+    return exc.errors.map((e) => e.message || String(e)).join("; ");
+  }
+  return String(exc?.message || exc);
+}

--- a/app/server.js
+++ b/app/server.js
@@ -18,7 +18,7 @@ import { createSqlEngine, listSqlEngines } from "./sqlEngines/index.js";
 import { formatKnowledge, loadKnowledge, selectRelevantKnowledge } from "./knowledge.js";
 import { validateSql } from "./sqlSafety.js";
 import { benchmarkStore } from "./benchmarks.js";
-import { log, warn } from "./logger.js";
+import { describeError, log, warn } from "./logger.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -243,7 +243,7 @@ Respond with ONLY a JSON array of 5 strings, no other text.`;
     }
     questions = parsed.slice(0, 5);
   } catch (exc) {
-    warn(`[examples] generation failed, using heuristic fallback: ${exc.message || exc}`);
+    warn(`[examples] generation failed, using heuristic fallback: ${describeError(exc)}`);
     questions = heuristicExampleQuestions(schema);
   }
 
@@ -329,7 +329,7 @@ async function runPipeline(question) {
     // Rethrown as-is (same behavior as before this log line was added) —
     // just makes sure a failure this early still gets a "done" timestamp
     // instead of silently having no closing log line for the request.
-    log(`[ask] done (error before SQL generation: ${String(exc.message || exc)})`);
+    log(`[ask] done (error before SQL generation: ${describeError(exc)})`);
     throw exc;
   }
 
@@ -404,7 +404,7 @@ async function runPipeline(question) {
       }
     }
   } catch (exc) {
-    output.error = String(exc.message || exc);
+    output.error = describeError(exc);
     log(`[ask] done (error: ${output.error})`);
   }
 
@@ -427,7 +427,7 @@ app.get("/api/schema", async (req, res) => {
   try {
     res.json(await getSchema());
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -437,7 +437,7 @@ app.get("/api/example-questions", async (req, res) => {
     const questions = await generateExampleQuestions(schema);
     res.json(questions);
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -474,7 +474,7 @@ app.post("/api/ask", async (req, res) => {
       warn(`[memory] write failed: ${err?.message || err}`);
     });
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -487,7 +487,7 @@ app.get("/api/memories", async (req, res) => {
     const memories = await fetchRelevantMemories(queryText, MEMORY, 3);
     res.json(memories);
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -520,7 +520,7 @@ app.post("/api/feedback", (req, res) => {
       });
     }
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -531,7 +531,7 @@ app.get("/api/benchmarks", (req, res) => {
   try {
     res.json(benchmarkStore.listCases());
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 
@@ -541,7 +541,7 @@ app.post("/api/benchmarks", (req, res) => {
     const entry = benchmarkStore.addCase({ question, groundTruthSql, source: "user" });
     res.status(201).json(entry);
   } catch (exc) {
-    res.status(400).json({ error: String(exc.message || exc) });
+    res.status(400).json({ error: describeError(exc) });
   }
 });
 
@@ -553,7 +553,7 @@ app.delete("/api/benchmarks/:id", (req, res) => {
     void invalidateFollowup(removed.question, MEMORY).catch(() => {});
     res.json({ ok: true });
   } catch (exc) {
-    res.status(400).json({ error: String(exc.message || exc) });
+    res.status(400).json({ error: describeError(exc) });
   }
 });
 
@@ -567,7 +567,7 @@ app.post("/api/memories/invalidate", async (req, res) => {
     const result = await invalidateFollowup(question, MEMORY);
     res.json(result);
   } catch (exc) {
-    res.status(500).json({ error: String(exc.message || exc) });
+    res.status(500).json({ error: describeError(exc) });
   }
 });
 

--- a/app/web/src/App.tsx
+++ b/app/web/src/App.tsx
@@ -61,6 +61,7 @@ function EmptyState({
 function App() {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [schema, setSchema] = useState<Schema | null>(null);
+  const [schemaError, setSchemaError] = useState<string | null>(null);
   const [conversations, setConversations] = useState<Conversation[]>(loadConversations);
   const [activeId, setActiveId] = useState<string | null>(() => loadConversations()[0]?.id ?? null);
   const [question, setQuestion] = useState("");
@@ -72,9 +73,22 @@ function App() {
   const activeConversation = conversations.find((c) => c.id === activeId) ?? null;
   const turns = activeConversation?.turns ?? [];
 
+  function loadSchema() {
+    setSchemaError(null);
+    fetchSchema()
+      .then((s) => {
+        setSchema(s);
+        setSchemaError(null);
+      })
+      .catch((exc: Error) => {
+        setSchema(null);
+        setSchemaError(exc.message);
+      });
+  }
+
   useEffect(() => {
     fetchConfig().then(setConfig).catch(() => setConfig(null));
-    fetchSchema().then(setSchema).catch(() => setSchema(null));
+    loadSchema();
   }, []);
 
 useEffect(() => {
@@ -155,6 +169,8 @@ useEffect(() => {
       <Sidebar
         config={config}
         schema={schema}
+        schemaError={schemaError}
+        onRetrySchema={loadSchema}
         conversations={conversations}
         activeId={activeId}
         onSelect={setActiveId}

--- a/app/web/src/components/Sidebar.tsx
+++ b/app/web/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import {
   Accordion,
   AccordionContent,
@@ -7,7 +8,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { getSqlEngineIcon } from "@/components/SqlEngineIcon";
 import type { AppConfig, Conversation, Schema } from "@/lib/types";
-import { MessageSquare, Plus, Server } from "lucide-react";
+import { AlertTriangle, MessageSquare, Plus, RefreshCw, Server } from "lucide-react";
 
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
@@ -20,6 +21,8 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
 export function Sidebar({
   config,
   schema,
+  schemaError,
+  onRetrySchema,
   conversations,
   activeId,
   onSelect,
@@ -27,11 +30,22 @@ export function Sidebar({
 }: {
   config: AppConfig | null;
   schema: Schema | null;
+  schemaError?: string | null;
+  onRetrySchema?: () => void;
   conversations: Conversation[];
   activeId: string | null;
   onSelect: (id: string) => void;
   onNewChat: () => void;
 }) {
+  // Controlled (rather than defaultValue) specifically so a connection
+  // error that arrives after initial mount (schema fetch is async) still
+  // forces this section open — an uncontrolled accordion's defaultValue is
+  // only read once, so it wouldn't react to an error appearing later.
+  const [openItems, setOpenItems] = useState<string[]>([]);
+  useEffect(() => {
+    if (schemaError) setOpenItems(["connection-info"]);
+  }, [schemaError]);
+
   return (
     <aside className="flex h-screen w-72 shrink-0 flex-col overflow-y-auto border-r bg-sidebar px-4 py-5">
       <div className="flex items-center gap-2">
@@ -73,10 +87,13 @@ export function Sidebar({
 
       <Separator className="my-4" />
 
-      <Accordion className="w-full">
+      <Accordion className="w-full" value={openItems} onValueChange={setOpenItems}>
         <AccordionItem value="connection-info">
           <AccordionTrigger className="py-1 text-xs font-medium">
-            Connection info
+            <span className="flex items-center gap-1.5">
+              Connection info
+              {schemaError && <AlertTriangle className="size-3.5 text-destructive" />}
+            </span>
           </AccordionTrigger>
           <AccordionContent>
             <FieldLabel>LLM</FieldLabel>
@@ -111,9 +128,31 @@ export function Sidebar({
                 {config.sqlEngineInfo.endpoint ? ` · ${config.sqlEngineInfo.endpoint}` : ""}
               </p>
             )}
+            {schemaError && (
+              <div className="mt-2 flex flex-col gap-1.5 rounded-lg border border-destructive/30 bg-destructive/10 p-2">
+                <div className="flex items-start gap-1.5 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                  <span className="break-words">Connection failed: {schemaError}</span>
+                </div>
+                {onRetrySchema && (
+                  <button
+                    type="button"
+                    onClick={onRetrySchema}
+                    className="flex w-fit items-center gap-1 rounded-md border border-destructive/30 px-2 py-1 text-[11px] font-medium text-destructive hover:bg-destructive/10"
+                  >
+                    <RefreshCw className="size-3" />
+                    Retry
+                  </button>
+                )}
+              </div>
+            )}
 
             <FieldLabel>Schema</FieldLabel>
-            {schema ? (
+            {schemaError ? (
+              <p className="text-xs text-muted-foreground">
+                Unavailable — fix the connection error above and retry.
+              </p>
+            ) : schema ? (
               <Accordion className="w-full">
                 {Object.entries(schema).map(([table, cols]) => (
                   <AccordionItem key={table} value={table}>

--- a/app/web/src/lib/api.ts
+++ b/app/web/src/lib/api.ts
@@ -7,6 +7,10 @@ export async function fetchConfig(): Promise<AppConfig> {
 
 export async function fetchSchema(): Promise<Schema> {
   const res = await fetch("/api/schema");
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Request failed (${res.status})`);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
Two real bugs found via a live, deliberately-broken Postgres connection test (a follow-up to reports of the webui "not loading anything"):

1. **`fetchSchema()` never checked `res.ok`** — a 500 error response (`{"error": "..."}`) got passed through as if it were valid `Schema` data and set directly into React state. The Sidebar then tried to render that error object as a table list, an unpredictable, confusing UI state with no indication anything was wrong.
2. **Connection-refused errors from `pg` surface as an unhelpful `AggregateError`** whose own `.message` is empty (literally the string `"AggregateError"`), with the real reason (`ECONNREFUSED`, etc.) buried in `.errors[]`. Every `String(exc.message || exc)` call in `server.js` was producing that useless string for exactly the errors a user most needs to read.

## Fix
- `logger.js` exports `describeError()` to unwrap `AggregateError`, used everywhere `server.js` formats an error for a response or log line
- `fetchSchema()` now throws with the real server error message on a non-ok response (matching the pattern already used elsewhere in `api.ts`)
- `App.tsx` captures that into a `schemaError` state instead of silently discarding it (`.catch(() => setSchema(null))` previously — no trace of what went wrong)
- Sidebar's "Connection info" section now shows a clear "Connection failed: `<message>`" banner with a Retry button, auto-opens itself when an error arrives (the accordion is now controlled, not relying on `defaultValue`, so it reacts even if the error appears after initial mount), and puts a warning icon on the collapsed trigger so the error is visible even collapsed

## Test plan
- [x] `node --check` on all changed backend files, `tsc -b --noEmit` clean, `npm run build` succeeds
- [x] `npm run benchmark` — 7/7 seed cases pass on the default `sqlite` engine
- [x] Deliberately pointed `SQL_ENGINE=postgres` at an unreachable host — confirmed `/api/schema` now returns `"connect ECONNREFUSED ::1:59999; connect ECONNREFUSED 127.0.0.1:59999"` instead of `"AggregateError"`
- [x] Verified no credentials/tokens present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)