### PR TITLE
Add pgvector as a pluggable cross-platform memory backend

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -63,6 +63,28 @@ MEMORY_TTL_SECONDS=604800
 # AWS credentials resolved via the standard SDK chain (env vars, profile,
 # instance role, etc.) — not read from these .env vars.
 
+# MEMORY_BACKEND=pgvector — any Postgres with the pgvector extension, covers
+# Databricks Lakebase directly (verified against a real Lakebase instance).
+# Auto-creates the extension/table/index on first use. Falls back to the
+# same connection as SQL_ENGINE=postgres (DB_URL / PG_*) if MEMORY_PG_* is
+# unset — override with MEMORY_PG_* to put memory on a different Postgres
+# instance than the one being queried.
+# MEMORY_BACKEND=pgvector
+# MEMORY_PG_URL=postgresql://user:password@host:5432/dbname?sslmode=require
+# MEMORY_PG_HOST=host          # ...or individual fields, same as PG_* above
+# MEMORY_PG_PORT=5432
+# MEMORY_PG_DATABASE=dbname
+# MEMORY_PG_USER=user
+# MEMORY_PG_PASSWORD=password
+# MEMORY_PG_SSL=default
+# MEMORY_ORG_ID=demo_org       # table name becomes db_agent_memory_<org_id>
+# MEMORY_VECTOR_DIM=768        # must match EMBEDDING_MODEL's output dimension
+#
+# The role connecting here needs INSERT/UPDATE/SELECT on its own
+# db_agent_memory_* table (and CREATE on the schema, the first time, to make
+# that table) — deliberately narrower than a full admin role. Do not reuse
+# a read-only role scoped for SQL_ENGINE=postgres; it can't write.
+
 # Embeddings default to LLM_BASE_URL/LLM_API_KEY (unset EMBEDDING_BASE_URL/
 # EMBEDDING_API_KEY below), but can point at a completely different endpoint
 # — chat/SQL-generation and embeddings are independent. This matters for

--- a/app/README.md
+++ b/app/README.md
@@ -182,7 +182,8 @@ documented-supported) — the deployment shape is the same generic
   pointed at the same store surface it as "Suggested from other agents" in
   the sidebar. Set `DBAGENT_ID` per instance (`run_local.sh` supports
   `DBAGENT_ID=oltp-sqlserver ./run_local.sh`, same as the Python app).
-  Two backends, selected via `MEMORY_BACKEND`:
+  Pluggable backends (`memoryBackends/`, same registry pattern as the SQL
+  engines above), selected via `MEMORY_BACKEND`:
   - `local` (default) — JSONL + cosine similarity, no cloud setup.
   - `s3vectors` — `@aws-sdk/client-s3vectors`, **verified end-to-end against
     real AWS** (a provisioned vector bucket + index, write from one agent,
@@ -199,6 +200,31 @@ documented-supported) — the deployment shape is the same generic
     (768 matches `nomic-embed-text`; use your embedding model's actual
     output dimension.) AWS credentials resolve via the standard SDK chain
     (env vars, shared config/profile, instance role, etc.).
+  - `milvus` — self-hosted or Zilliz Cloud, via `@zilliz/milvus2-sdk-node`.
+    Auto-creates its collection/index on first use.
+  - `pgvector` — any Postgres with the `pgvector` extension, via `pg` (the
+    same driver `SQL_ENGINE=postgres` uses). Covers **Databricks Lakebase
+    directly** — **verified end-to-end against a real Lakebase instance**
+    (`pgvector` 0.8, HNSW index, confirmed present before writing this):
+    `put`/`query` with correct self-exclusion and TTL filtering, and
+    `invalidateFollowup` as an exact match over a real array column rather
+    than the best-effort semantic lookup the other two vector backends need
+    (see `memoryBackends/pgvector.js`'s header comment for why Postgres
+    doesn't need that workaround — it can do similarity ranking, TTL
+    filtering, and self-exclusion in one indexed query). Auto-creates the
+    extension/table/index on first use; falls back to the same connection
+    as `SQL_ENGINE=postgres` (`DB_URL`/`PG_*`) if `MEMORY_PG_*` is unset.
+
+    The connecting role needs `INSERT`/`UPDATE`/`SELECT` on its own
+    `db_agent_memory_*` table (and `CREATE` on the schema, the first time,
+    to make that table) — **do not reuse a read-only role** scoped for
+    `SQL_ENGINE=postgres`, it can't write:
+    ```sql
+    CREATE EXTENSION IF NOT EXISTS vector;
+    CREATE ROLE db_agent_memory_rw WITH LOGIN PASSWORD '...';
+    GRANT CONNECT ON DATABASE your_db TO db_agent_memory_rw;
+    GRANT USAGE, CREATE ON SCHEMA public TO db_agent_memory_rw;
+    ```
 
   **Chat and embeddings are independent endpoints** (`EMBEDDING_BASE_URL`/
   `EMBEDDING_API_KEY`, default to `LLM_BASE_URL`/`LLM_API_KEY` if unset).

--- a/app/memoryBackends/index.js
+++ b/app/memoryBackends/index.js
@@ -13,6 +13,7 @@ import path from "node:path";
 import { LocalJsonBackend } from "./local.js";
 import { S3VectorsBackend } from "./s3vectors.js";
 import { MilvusBackend } from "./milvus.js";
+import { PgVectorBackend } from "./pgvector.js";
 
 const REGISTRY = {
   local: {
@@ -46,6 +47,39 @@ const REGISTRY = {
         password: env.MILVUS_PASSWORD,
         ssl: (env.MILVUS_SSL || "false").toLowerCase() === "true",
       }),
+  },
+  pgvector: {
+    description:
+      "Any Postgres database with the pgvector extension (covers Databricks Lakebase directly). Auto-creates its table/index on first use.",
+    create: (env) => {
+      // Falls back to the same connection as the `postgres` SQL engine
+      // (DB_URL / PG_*) since pointing memory at the same Lakebase/Postgres
+      // instance already being queried is the common case — override with
+      // MEMORY_PG_* to put memory on a different Postgres instance.
+      const connectionString = env.MEMORY_PG_URL || env.DB_URL || undefined;
+      if (!connectionString && !(env.MEMORY_PG_HOST || env.PG_HOST)) {
+        throw new Error(
+          "MEMORY_BACKEND=pgvector requires MEMORY_PG_URL/DB_URL or MEMORY_PG_HOST+PG_HOST (see .env.example)."
+        );
+      }
+      const orgId = env.MEMORY_ORG_ID || "demo_org";
+      const table = "db_agent_memory_" + orgId.toLowerCase().replace(/[^a-z0-9_]/g, "_");
+      return new PgVectorBackend({
+        connectionString,
+        host: env.MEMORY_PG_HOST || env.PG_HOST,
+        port: env.MEMORY_PG_PORT || env.PG_PORT || "5432",
+        database: env.MEMORY_PG_DATABASE || env.PG_DATABASE,
+        user: env.MEMORY_PG_USER || env.PG_USER,
+        password: env.MEMORY_PG_PASSWORD || env.PG_PASSWORD,
+        ssl: env.MEMORY_PG_SSL || env.PG_SSL || "default",
+        // Must match EMBEDDING_MODEL's output dimension exactly — same
+        // constraint as the other two vector backends, just enforced via
+        // the VECTOR(n) column type here instead of an out-of-band index
+        // creation call.
+        dimension: Number(env.MEMORY_VECTOR_DIM || 768),
+        table,
+      });
+    },
   },
 };
 

--- a/app/memoryBackends/pgvector.js
+++ b/app/memoryBackends/pgvector.js
@@ -1,0 +1,142 @@
+// memoryBackends/pgvector.js — any standard Postgres database with the
+// pgvector extension available, via node-postgres (same driver as
+// sqlEngines/postgres.js — reuses the dependency, adds nothing new).
+// Covers Databricks Lakebase directly, which ships pgvector 0.8+ with both
+// ivfflat and hnsw index types (verified against a real Lakebase instance
+// before writing this).
+//
+// Cleaner than the other two vector backends in a few concrete ways, not
+// just "another option": Postgres can do similarity ranking, TTL
+// filtering, and self-exclusion in one indexed query (`ORDER BY embedding
+// <=> $vector` combined with a plain `WHERE` clause) — S3VectorsBackend
+// and MilvusBackend both over-fetch and filter client-side because their
+// query APIs don't support that combination. And invalidateFollowup here
+// is an exact match over a real array column, not a best-effort semantic
+// lookup near the invalidated question's own embedding — Postgres just
+// doesn't have the "vector search is the only way to find anything"
+// limitation those two have.
+
+import pg from "pg";
+import { normalizeQuestion } from "../memory.js";
+
+const { Pool } = pg;
+
+function quoteIdent(id) {
+  return `"${String(id).replace(/"/g, '""')}"`;
+}
+
+function sslOption(ssl) {
+  // Same reasoning as sqlEngines/postgres.js's identical helper — managed
+  // Postgres (Lakebase included) requires TLS, and its CA chain often
+  // isn't in Node's default trust store.
+  if (ssl === "strict") return true;
+  if (ssl === "false") return false;
+  return { rejectUnauthorized: false };
+}
+
+export class PgVectorBackend {
+  constructor({ connectionString, host, port, database, user, password, ssl, dimension, table }) {
+    this.dimension = dimension;
+    this.table = table;
+    this.pool = connectionString
+      ? new Pool({ connectionString, ssl: sslOption(ssl) })
+      : new Pool({ host, port: Number(port) || 5432, database, user, password, ssl: sslOption(ssl) });
+    // Extension/table/index creation is async and can't happen in a
+    // constructor — every public method awaits this first, same lazy-init
+    // pattern as MilvusBackend.ensureCollection().
+    this.ready = this.init();
+  }
+
+  async init() {
+    await this.pool.query("CREATE EXTENSION IF NOT EXISTS vector");
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS ${quoteIdent(this.table)} (
+        record_id TEXT PRIMARY KEY,
+        source_agent TEXT NOT NULL,
+        source_db_kind TEXT,
+        created_at TEXT,
+        ttl_epoch BIGINT,
+        entities TEXT[],
+        insight_summary TEXT,
+        suggested_followups TEXT[],
+        embedding VECTOR(${this.dimension})
+      )
+    `);
+    // HNSW over ivfflat: builds incrementally (ivfflat needs representative
+    // data present before it clusters well) and pgvector 0.8 (confirmed
+    // available) supports it — better fit for a store that starts empty
+    // and grows one write at a time.
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS ${quoteIdent(this.table + "_embedding_hnsw")}
+      ON ${quoteIdent(this.table)} USING hnsw (embedding vector_cosine_ops)
+    `);
+  }
+
+  async put(record, vector) {
+    await this.ready;
+    await this.pool.query(
+      `INSERT INTO ${quoteIdent(this.table)}
+        (record_id, source_agent, source_db_kind, created_at, ttl_epoch, entities, insight_summary, suggested_followups, embedding)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::vector)`,
+      [
+        record.recordId,
+        record.sourceAgent,
+        record.sourceDbKind,
+        record.createdAt,
+        record.ttlEpoch,
+        record.entities || [],
+        record.insightSummary,
+        record.suggestedFollowups || [],
+        JSON.stringify(vector),
+      ]
+    );
+  }
+
+  async query(vector, { excludeAgent, topK }) {
+    await this.ready;
+    const now = Math.floor(Date.now() / 1000);
+    const { rows } = await this.pool.query(
+      `SELECT record_id, source_agent, source_db_kind, created_at, ttl_epoch, entities, insight_summary, suggested_followups
+       FROM ${quoteIdent(this.table)}
+       WHERE ttl_epoch > $1 AND source_agent != $2
+       ORDER BY embedding <=> $3::vector
+       LIMIT $4`,
+      [now, excludeAgent, JSON.stringify(vector), topK]
+    );
+    return rows.map((r) => ({
+      recordId: r.record_id,
+      sourceAgent: r.source_agent,
+      sourceDbKind: r.source_db_kind,
+      createdAt: r.created_at,
+      ttlEpoch: Number(r.ttl_epoch),
+      entities: r.entities || [],
+      insightSummary: r.insight_summary,
+      suggestedFollowups: r.suggested_followups || [],
+    }));
+  }
+
+  // Exact match over the real array column — no vector search needed here
+  // at all, unlike the other two backends. Table sizes this is meant for
+  // make a full scan of two columns cheap; only rows that actually change
+  // get written back.
+  async invalidateFollowup(questionText) {
+    await this.ready;
+    const target = normalizeQuestion(questionText);
+    const { rows } = await this.pool.query(
+      `SELECT record_id, suggested_followups FROM ${quoteIdent(this.table)}`
+    );
+
+    let removed = 0;
+    for (const row of rows) {
+      const followups = row.suggested_followups || [];
+      const filtered = followups.filter((f) => normalizeQuestion(f) !== target);
+      if (filtered.length === followups.length) continue;
+      removed += followups.length - filtered.length;
+      await this.pool.query(
+        `UPDATE ${quoteIdent(this.table)} SET suggested_followups = $1 WHERE record_id = $2`,
+        [filtered, row.record_id]
+      );
+    }
+    return { removed };
+  }
+}


### PR DESCRIPTION
## Summary
- New `memoryBackends/pgvector.js`: any Postgres with the `pgvector` extension, via `node-postgres` (the same driver `SQL_ENGINE=postgres` already uses — no new dependency)
- Covers **Databricks Lakebase directly** — verified `pgvector` 0.8 with HNSW indexing is actually available on a real Lakebase instance before writing this, not assumed
- Auto-creates the extension/table/index on first use; falls back to the same connection as `SQL_ENGINE=postgres` (`DB_URL`/`PG_*`) if `MEMORY_PG_*` is unset

## Why this one's a step up, not just a third option
Postgres does similarity ranking, TTL filtering, and self-exclusion in **one indexed query** (`ORDER BY embedding <=> $vector` combined with a plain `WHERE` clause) — `S3VectorsBackend` and `MilvusBackend` both over-fetch and filter client-side because their query APIs can't combine those. `invalidateFollowup` here is an **exact match** over a real array column, not the best-effort semantic lookup near the invalidated question's own embedding the other two need — Postgres doesn't have the "vector search is the only way to find anything" limitation they do.

## Security note
The connecting role needs `INSERT`/`UPDATE`/`SELECT` on its own `db_agent_memory_*` table (and `CREATE` on the schema, the first time) — deliberately narrower than the app's SQL-engine role. README calls out explicitly: don't reuse a read-only role scoped for `SQL_ENGINE=postgres`, it can't write.

## Test plan
- [x] `node --check` on all changed/new backend files, `tsc -b --noEmit` clean
- [x] `npm run benchmark` — 7/7 seed cases pass on `sqlite`/`local` (zero-config default unaffected)
- [x] **Verified end-to-end against a real Lakebase instance**: extension/table/index creation, `put`, `query` (both self-exclusion and cross-agent visibility confirmed), `invalidateFollowup` (exact removal of one follow-up, sibling entries left untouched), and the full `server.js` pipeline via a real `/api/ask` request landing a redacted memory record in the live table
- [x] Verified no credentials/tokens present in the diff (only a placeholder `'...'` password in the README's setup SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)